### PR TITLE
Introduce fast switchovers/failovers

### DIFF
--- a/doc/config.md.diff
+++ b/doc/config.md.diff
@@ -1,0 +1,25 @@
+diff --git a/doc/config.md b/doc/config.md
+index b181730..218cf38 100644
+--- a/doc/config.md
++++ b/doc/config.md
+@@ -131,6 +131,20 @@ the per-database configuration.
+ 
+ Default: 20
+ 
++### polling_frequency
++
++How often to poll the other nodes in a cluster if using the fast switchover feature.
++The query used to poll the nodes is `pg_is_in_recovery()`.
++
++Default: .1 (100ms)
++
++### server_failed_delay
++
++How long to wait between failed attempts to reconnect to a downed node when using fast
++switchovers. This prevents connection storming downed nodes.
++
++Default: 30
++
+ ### min_pool_size
+ 
+ Add more server connections to pool if below this number.

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,9 +1,8 @@
---- ../pgbouncer/include/bouncer.h	2020-04-26 15:20:51.657323344 -0400
-+++ ./include/bouncer.h	2020-04-26 14:57:50.252491469 -0400
-@@ -97,12 +97,17 @@ typedef union PgAddr PgAddr;
- typedef enum SocketState SocketState;
- typedef struct PktHdr PktHdr;
- typedef struct ScramState ScramState;
+diff --git a/include/bouncer.h b/include/bouncer.h
+index f2c2bac..ddb07fc 100644
+--- a/include/bouncer.h
++++ b/include/bouncer.h
+@@ -99,6 +99,11 @@ typedef struct ScramState ScramState;
  
  extern int cf_sbuf_len;
  
@@ -15,13 +14,52 @@
  #include "util.h"
  #include "iobuf.h"
  #include "sbuf.h"
- #include "pktbuf.h"
- #include "varcache.h"
- #include "dnslookup.h"
-@@ -512,12 +517,17 @@ extern int cf_tcp_user_timeout;
+@@ -374,12 +379,20 @@ struct PgPool {
  
- extern int cf_log_connections;
- extern int cf_log_disconnections;
+ 	/* if last connect to server failed, there should be delay before next */
+ 	usec_t last_connect_time;
++	usec_t last_poll_time;
++	usec_t last_failed_time; // last time the connection failed
+ 	bool last_connect_failed:1;
+ 	bool last_login_failed:1;
+ 
+ 	bool welcome_msg_ready:1;
++	bool recently_checked:1; // should be set once checking starts. If all pools have this set, they need to be unset so we can loop again.
++	bool initial_writer_endpoint:1; // used to indicate a configured writer when starting PgBouncer. Used for getting the topology of the cluster associated with the writer.
+ 
++	uint16_t num_nodes;
+ 	uint16_t rrcounter;		/* round-robin counter */
++
++	PgPool *global_writer;	/* global_writer pool for this pool */;
++	PgPool *parent_pool;	/* the parent pool for setting the global writer */
+ };
+ 
+ /*
+@@ -466,6 +479,7 @@ struct PgDatabase {
+ 	int pool_mode;		/* pool mode for this database */
+ 	int max_db_connections;	/* max server connections between all pools */
+ 	char *connect_query;	/* startup commands to send to server after connect */
++	char *topology_query;	/* command to get topology to determine promoted writer. Also used to indicate whether to use fast_switchovers on a specific node */
+ 
+ 	struct PktBuf *startup_params; /* partial StartupMessage (without user) be sent to server */
+ 	const char *dbname;	/* server-side name, pointer to inside startup_msg */
+@@ -598,6 +612,7 @@ extern int cf_peer_id;
+ extern int cf_pool_mode;
+ extern int cf_max_client_conn;
+ extern int cf_default_pool_size;
++extern usec_t cf_polling_frequency;
+ extern int cf_min_pool_size;
+ extern int cf_res_pool_size;
+ extern usec_t cf_res_pool_timeout;
+@@ -615,6 +630,7 @@ extern int cf_server_reset_query_always;
+ extern char * cf_server_check_query;
+ extern usec_t cf_server_check_delay;
+ extern int cf_server_fast_close;
++extern usec_t cf_server_failed_delay;
+ extern usec_t cf_server_connect_timeout;
+ extern usec_t cf_server_login_retry;
+ extern usec_t cf_query_timeout;
+@@ -667,6 +683,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  
@@ -33,6 +71,3 @@
  extern int cf_client_tls_sslmode;
  extern char *cf_client_tls_protocols;
  extern char *cf_client_tls_ca_file;
- extern char *cf_client_tls_cert_file;
- extern char *cf_client_tls_key_file;
- extern char *cf_client_tls_ciphers;

--- a/include/janitor.h.diff
+++ b/include/janitor.h.diff
@@ -1,0 +1,12 @@
+diff --git a/include/janitor.h b/include/janitor.h
+index c4e5ab4..016f93b 100644
+--- a/include/janitor.h
++++ b/include/janitor.h
+@@ -20,6 +20,7 @@ void janitor_setup(void);
+ void config_postprocess(void);
+ void resume_all(void);
+ void per_loop_maint(void);
++void run_once_to_init(void);
+ bool suspend_socket(PgSocket *sk, bool force)  _MUSTCHECK;
+ void kill_pool(PgPool *pool);
+ void kill_peer_pool(PgPool *pool);

--- a/include/loader.h.diff
+++ b/include/loader.h.diff
@@ -1,0 +1,10 @@
+diff --git a/include/loader.h b/include/loader.h
+index dabfc51..8f7ed38 100644
+--- a/include/loader.h
++++ b/include/loader.h
+@@ -25,3 +25,5 @@ bool parse_user(void *base, const char *name, const char *params) _MUSTCHECK;
+ /* user file parsing */
+ bool load_auth_file(const char *fn)  /* _MUSTCHECK */;
+ bool loader_users_check(void)  /* _MUSTCHECK */;
++
++PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname);

--- a/include/objects.h.diff
+++ b/include/objects.h.diff
@@ -1,0 +1,13 @@
+diff --git a/include/objects.h b/include/objects.h
+index 7f64ce1..1360807 100644
+--- a/include/objects.h
++++ b/include/objects.h
+@@ -32,6 +32,8 @@ extern struct Slab *peer_pool_cache;
+ extern struct Slab *pool_cache;
+ extern struct Slab *user_cache;
+ extern struct Slab *iobuf_cache;
++extern bool fast_switchover;
++extern bool checking_for_new_writer; // this is linked with server and client so we can communicate when polling is truly done. Used to only allow checking for one node a time.
+ 
+ PgDatabase *find_peer(int peer_id);
+ PgDatabase *find_database(const char *name);

--- a/include/pktbuf.h.diff
+++ b/include/pktbuf.h.diff
@@ -1,0 +1,13 @@
+diff --git a/include/pktbuf.h b/include/pktbuf.h
+index fbe1fc5..83d9587 100644
+--- a/include/pktbuf.h
++++ b/include/pktbuf.h
+@@ -47,6 +47,8 @@ void pktbuf_free(PktBuf *buf);
+ void pktbuf_reset(struct PktBuf *pkt);
+ struct PktBuf *pktbuf_temp(void);
+ 
++PktBuf *pktbuf_copy(PktBuf *orig);
++
+ 
+ /*
+  * sending

--- a/include/util.h.diff
+++ b/include/util.h.diff
@@ -1,0 +1,21 @@
+diff --git a/include/util.h b/include/util.h
+index 35a284b..32e9782 100644
+--- a/include/util.h
++++ b/include/util.h
+@@ -19,6 +19,16 @@
+ #include <usual/logging.h>
+ #include <usual/string.h>
+ 
++/*
++ * sets the global writer to NULL for the pool
++ */
++void clear_global_writer(PgPool *pool);
++
++/*
++ * get the global writer, if any from the pool
++ */
++PgPool *get_global_writer(PgPool *pool);
++
+ /*
+  * logging about specific socket
+  */

--- a/install-pgbouncer-rr-patch.sh
+++ b/install-pgbouncer-rr-patch.sh
@@ -34,6 +34,19 @@ MERGEFILES="\
    src/client.c\
    src/main.c\
    include/bouncer.h\
+   include/janitor.h\
+   include/loader.h\
+   include/objects.h\
+   include/pktbuf.h\
+   include/util.h\
+   src/admin.c\
+   src/janitor.c\
+   src/loader.c\
+   src/objects.c\
+   src/pktbuf.c\
+   src/server.c\
+   src/util.c\
+   doc/config.md\
    "
 for file in $MERGEFILES
 do

--- a/install-pgbouncer-rr-patch.sh
+++ b/install-pgbouncer-rr-patch.sh
@@ -89,7 +89,7 @@ if [ $patchstatus -eq 1 ]; then
    echo "Possible causes: "
    echo "   pgbouncer-rr-patch already installed in target directory?"
    echo "   new version of pgbouncer with changed source files that can't be patched?"
-   echo "      - last tested with pgbouncer v1.12 (April 2020)"
+   echo "      - last tested with pgbouncer v1.19 (September 2023)"
    echo "      - Try getting pgbouncer with: git clone https://github.com/pgbouncer/pgbouncer.git --branch \"stable-1.19\""
    echo "Status: pgbouncer-rr-patch merge FAILED"
 else

--- a/src/admin.c.diff
+++ b/src/admin.c.diff
@@ -1,0 +1,12 @@
+diff --git a/src/admin.c b/src/admin.c
+index 0cf2e8b..c4dbfde 100644
+--- a/src/admin.c
++++ b/src/admin.c
+@@ -1093,6 +1093,7 @@ static bool admin_cmd_reload(PgSocket *admin, const char *arg)
+ 	load_config();
+ 	if (!sbuf_tls_setup())
+ 		log_error("TLS configuration could not be reloaded, keeping old configuration");
++	run_once_to_init();
+ 	return admin_ready(admin, "RELOAD");
+ }
+ 

--- a/src/client.c.diff
+++ b/src/client.c.diff
@@ -1,6 +1,8 @@
---- ../pgbouncer/src/client.c	2020-04-26 15:20:51.660323326 -0400
-+++ ./src/client.c	2020-04-26 15:19:04.085959392 -0400
-@@ -545,10 +545,10 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
+diff --git a/src/client.c b/src/client.c
+index 464d78d..ff64c08 100644
+--- a/src/client.c
++++ b/src/client.c
+@@ -585,10 +585,10 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
  		} else if (strcmp(key, "application_name") == 0) {
  			set_appname(client, val);
  			appname_found = true;
@@ -13,7 +15,16 @@
  		} else {
  			slog_warning(client, "unsupported startup parameter: %s=%s", key, val);
  			disconnect_client(client, true, "unsupported startup parameter: %s", key);
-@@ -883,7 +883,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
+@@ -798,7 +798,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
+ 			return false;
+ 		}
+ 
+-		if (client->pool && !client->wait_for_user_conn && !client->wait_for_user) {
++		if (client->pool && !client->wait_for_user_conn && !client->wait_for_user && !get_global_writer(client->pool)) {
+ 			disconnect_client(client, true, "client re-sent startup pkt");
+ 			return false;
+ 		}
+@@ -923,7 +923,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
  static bool handle_client_work(PgSocket *client, PktHdr *pkt)
  {
  	SBuf *sbuf = &client->sbuf;
@@ -22,7 +33,7 @@
  
  	switch (pkt->type) {
  
-@@ -940,8 +940,11 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
+@@ -980,8 +980,11 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
  		client->query_start = get_cached_time();
  	}
  
@@ -35,7 +46,7 @@
  		client->pool->stats.xact_count++;
  		client->xact_start = client->query_start;
  	}
-@@ -949,6 +952,14 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
+@@ -989,6 +992,14 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
  	if (client->pool->db->admin)
  		return admin_handle_client(client, pkt);
  

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,0 +1,306 @@
+diff --git a/src/janitor.c b/src/janitor.c
+index 855a4c5..03ffc51 100644
+--- a/src/janitor.c
++++ b/src/janitor.c
+@@ -24,6 +24,9 @@
+ 
+ #include <usual/slab.h>
+ 
++bool fast_switchover = false;
++bool checking_for_new_writer = false;
++
+ /* do full maintenance 3x per second */
+ static struct timeval full_maint_period = {0, USEC / 3};
+ static struct event full_maint_ev;
+@@ -125,21 +128,132 @@ void resume_all(void)
+ 	resume_pooler();
+ }
+ 
++static bool update_client_pool(PgSocket *client, PgPool *new_pool)
++{
++	char *username = NULL;
++	char *passwd = NULL;
++
++	if (client->pool == new_pool)
++		return true;
++
++	username = client->login_user->name;
++	passwd = client->login_user->passwd;
++	if (!set_pool(client, new_pool->db->name, username, passwd, true)) {
++		log_error("could not set pool to: %s", new_pool->db->name);
++		return false;
++	}
++
++	return true;
++}
++
++static void reset_recently_checked(void)
++{
++	struct List *item;
++	PgPool *pool;
++
++	statlist_for_each(item, &pool_list) {
++		pool = container_of(item, PgPool, head);
++		if (pool->db->admin)
++			continue;
++
++		if (!pool->db->topology_query)
++			continue;
++
++		log_debug("resetting pool: %s", pool->db->name);
++		pool->recently_checked = false;
++	}
++}
++
+ /*
+- * send test/reset query to server if needed
++ * send test/reset query to server if needed. If using fast switchovers,
++ * this is the entry point for finding the new writer.
+  */
+-static void launch_recheck(PgPool *pool)
++static void launch_recheck(PgPool *pool, PgSocket *client)
+ {
+-	const char *q = cf_server_check_query;
++	char *q = cf_server_check_query;
+ 	bool need_check = true;
+ 	PgSocket *server;
+ 	bool res = true;
++	struct List *item;
++	PgPool *next_pool;
++	usec_t polling_freq_in_ms = cf_polling_frequency / 1000;
++	usec_t last_poll_time;
++	usec_t difference_in_ms;
++	usec_t now;
++	PgPool *global_writer = get_global_writer(pool);
++
++	log_debug("launch_recheck: for db: %s, global_writer? %s", pool->db->name, global_writer ? global_writer->db->name : "no global_writer");
++
++	if (checking_for_new_writer) {
++		log_debug("launch_recheck: checking_for_new_writer is true so a node is being checked if it is a writer already, skipping");
++		return;
++	}
++
++	if (!pool->db->topology_query) {
++		log_debug("launch_recheck: no topology_query for this pool, so proceeding without cache");
++	} else if (global_writer) {
++		log_debug("launch_recheck: global writer is set: using cached pool: %s", global_writer->db->name);
++		update_client_pool(client, global_writer);
++	} else if (pool->last_connect_failed) {
++		bool found = false;
++		reset_time_cache();
++		now = get_cached_time();
++		log_debug("launch_recheck: need to iterate pool list");
++
++		statlist_for_each(item, &pool_list) {
++			next_pool = container_of(item, PgPool, head);
++
++			if (!next_pool->parent_pool || next_pool->parent_pool != pool) {
++				continue;
++			}
++
++			if (next_pool->last_connect_failed)
++				continue;
++
++			if (next_pool->recently_checked) {
++				log_debug("pool was recently checked, skipping: %s", next_pool->db->name);
++				continue;
++			}
++
++			last_poll_time = next_pool->last_poll_time;
++			difference_in_ms = (now - last_poll_time) / 1000;
++			log_debug("last time checked for pool %s: now: %llu last: %llu, diff: %llu, polling_freq_max: %llu", next_pool->db->name, now, last_poll_time, difference_in_ms, cf_polling_frequency/1000);
++
++			if (difference_in_ms < polling_freq_in_ms) {
++				log_debug("skipping because it's too soon for pool %s (%llu ms)", next_pool->db->name, difference_in_ms);
++				continue;
++			}
++
++			log_debug("found pool during iteration, setting to: %s", next_pool->db->name);
++
++			found = update_client_pool(client, next_pool);
++			if (!found)
++				return;
++
++			break;
++		}
++
++		if (!found) {
++			log_debug("could not find alternate server, need to reset all pools");
++			reset_recently_checked();
++			/* drastically reduces switchover/failover time since we don't need to wait to get called again from per_loop_activate() */
++			launch_recheck(pool, client);
++
++			return;
++		} else {
++			next_pool->last_poll_time = now;
++			next_pool->recently_checked = true;
++		}
++	}
+ 
+ 	/* find clean server */
+ 	while (1) {
+-		server = first_socket(&pool->used_server_list);
+-		if (!server)
++		server = first_socket(&client->pool->used_server_list);
++		if (!server) {
++			// need to reset
++			client->pool->last_connect_failed = true;
+ 			return;
++		}
+ 		if (server->ready)
+ 			break;
+ 		disconnect_server(server, true, "idle server got dirty");
+@@ -155,12 +269,32 @@ static void launch_recheck(PgPool *pool)
+ 	}
+ 
+ 	if (need_check) {
+-		/* send test query, wait for result */
+-		slog_debug(server, "P: checking: %s", q);
+-		change_server_state(server, SV_TESTED);
+-		SEND_generic(res, server, 'Q', "s", q);
+-		if (!res)
+-			disconnect_server(server, false, "test query failed");
++		if (fast_switchover && pool->db->topology_query && !global_writer) {
++			checking_for_new_writer = true;
++			q = strdup("select pg_is_in_recovery()");
++			if (q == NULL) {
++				log_error("strdup: no mem for pg_is_in_recovery()");
++				return;
++			}
++			slog_debug(server, "P: checking: %s (not done polling)", q);
++			SEND_generic(res, server, 'Q', "s", q);
++			if (!res)
++				disconnect_server(server, false, "pg_is_in_recovery() query failed");
++			free(q);
++		} else {
++			reset_recently_checked();
++
++			slog_debug(server, "P: checking: %s (done polling)", q);
++			change_server_state(server, SV_TESTED);
++			SEND_generic(res, server, 'Q', "s", q);
++			if (!res)
++				disconnect_server(server, false, "test query failed");
++
++			/* reactivate paused clients that never finished logging in */
++			if (client->state == CL_WAITING_LOGIN || client->state == CL_WAITING) {
++				activate_client(client);
++			}
++		}
+ 	} else {
+ 		/* make immediately available */
+ 		release_server(server);
+@@ -202,11 +336,22 @@ static void per_loop_activate(PgPool *pool)
+ 			--sv_tested;
+ 		} else if (sv_used > 0) {
+ 			/* ask for more connections to be tested */
+-			launch_recheck(pool);
++			launch_recheck(pool, client);
+ 			--sv_used;
+ 		} else {
+ 			/* not enough connections */
+-			launch_new_connection(pool, /* evict_if_needed= */ true);
++			log_debug("launch_new_connection because not enough connections. number pools: %d, for: %s", statlist_count(&pool_list), pool->db->name);
++
++			if (fast_switchover && pool->db->topology_query &&
++			 	(!get_global_writer(pool) || pool->last_connect_failed)) {
++				log_debug("launch_new_connection loop: going to try to use pool cache since this pool was a writer: last_connect_failed (%d)",
++						pool->last_connect_failed);
++				launch_recheck(pool, client);
++			} else {
++				log_debug("launch_new_connection loop: need to launch new connection because pool is not already a writer");
++				launch_new_connection(pool, /* evict_if_needed= */ true);
++			}
++
+ 			break;
+ 		}
+ 	}
+@@ -298,10 +443,7 @@ static int per_loop_wait_close(PgPool *pool)
+ 	return count;
+ }
+ 
+-/*
+- * this function is called for each event loop.
+- */
+-void per_loop_maint(void)
++static void loop_maint(bool initialize)
+ {
+ 	struct List *item;
+ 	PgPool *pool;
+@@ -310,6 +452,7 @@ void per_loop_maint(void)
+ 	bool partial_pause = false;
+ 	bool partial_wait = false;
+ 	bool force_suspend = false;
++	usec_t now = get_cached_time();
+ 
+ 	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
+ 		usec_t stime = get_cached_time() - g_suspend_start;
+@@ -321,13 +464,32 @@ void per_loop_maint(void)
+ 		pool = container_of(item, PgPool, head);
+ 		if (pool->db->admin)
+ 			continue;
++
++		if (initialize) {
++			if (!pool->db->topology_query)
++				continue;
++
++			pool->initial_writer_endpoint = true;
++			log_debug("create initial pool during startup for: %s", pool->db->name);
++		} else {
++			if (fast_switchover && pool->last_connect_failed && get_global_writer(pool)) {
++				if (now - pool->last_failed_time > cf_server_failed_delay) {
++					log_debug("last connect failed: %s, so launching new connection in per_loop_maint", pool->db->name);
++					launch_new_connection(pool, true);
++				}
++			}
++		}
++
+ 		switch (cf_pause_mode) {
+ 		case P_NONE:
+ 			if (pool->db->db_paused) {
+ 				partial_pause = true;
+ 				active_count += per_loop_pause(pool);
+ 			} else {
+-				per_loop_activate(pool);
++				if (initialize)
++					launch_new_connection(pool, false);
++				else
++					per_loop_activate(pool);
+ 			}
+ 			break;
+ 		case P_PAUSE:
+@@ -366,6 +528,27 @@ void per_loop_maint(void)
+ 		admin_wait_close_done();
+ }
+ 
++/*
++ * Used to pre-create connection pools at pgbouncer init time.
++ */
++void run_once_to_init(void)
++{
++	if (!fast_switchover) {
++		log_debug("database does not have fast_switchovers enabled, so will not precreate pools to nodes");
++		return;
++	}
++
++	loop_maint(true);
++}
++
++/*
++ * this function is called for each event loop.
++ */
++void per_loop_maint(void)
++{
++	loop_maint(false);
++}
++
+ /* maintaining clients in pool */
+ static void pool_client_maint(PgPool *pool)
+ {
+@@ -801,6 +984,7 @@ void kill_database(PgDatabase *db)
+ 	if (db->forced_user)
+ 		slab_free(user_cache, db->forced_user);
+ 	free(db->connect_query);
++	free(db->topology_query);
+ 	if (db->inactive_time) {
+ 		statlist_remove(&autodatabase_idle_list, &db->head);
+ 	} else {

--- a/src/loader.c.diff
+++ b/src/loader.c.diff
@@ -1,0 +1,149 @@
+diff --git a/src/loader.c b/src/loader.c
+index 55f87a8..e6c8d2b 100644
+--- a/src/loader.c
++++ b/src/loader.c
+@@ -260,6 +260,76 @@ fail:
+ 	free(tmp_connstr);
+ 	return false;
+ }
++
++PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname)
++{
++	PgPool *pool;
++	PgDatabase *new_db = find_database(dbname);
++	if (new_db) {
++		log_debug("db already exists, so won't create db from db: %s", dbname);
++		return NULL;
++	}
++
++	new_db = add_database(dbname);
++	if (!new_db)
++		goto oom;
++
++	if (db->startup_params) {
++		new_db->startup_params = pktbuf_copy(db->startup_params);
++		if (new_db->startup_params == NULL)
++			goto oom;
++	}
++
++	/* tag the db as alive */
++	new_db->db_dead = false;
++	/* assuming not an autodb */
++	new_db->db_auto = false;
++	new_db->inactive_time = 0;
++
++	new_db->host = strdup(hostname);
++	if (!new_db->host)
++		goto oom;
++
++	new_db->port = db->port;
++	new_db->pool_size = db->pool_size;
++	new_db->min_pool_size = db->min_pool_size;
++	new_db->res_pool_size = db->res_pool_size;
++	new_db->pool_mode = db->pool_mode;
++	new_db->max_db_connections = db->max_db_connections;
++	if (db->connect_query) {
++		new_db->connect_query = strdup(db->connect_query);
++		if (!new_db->connect_query)
++			goto oom;
++	}
++	if (new_db->topology_query) {
++		new_db->topology_query = strdup(db->topology_query);
++		if (!new_db->topology_query)
++			goto oom;
++	}
++	if (db->auth_dbname) {
++		new_db->auth_dbname = strdup(db->auth_dbname);
++		if (!new_db->auth_dbname)
++			goto oom;
++	}
++
++	if (db->forced_user) {
++		if (!force_user(new_db, db->forced_user->name, db->forced_user->passwd)) {;
++			goto oom;
++		}
++	}
++
++	log_debug("creating pool for %s", new_db->name);
++	pool = get_pool(new_db, new_db->forced_user);
++	if (!pool) {
++		fatal("pool could not be created for %s", new_db->name);
++		goto oom;
++	}
++	return pool;
++
++oom:
++	die("out of memory");
++}
++
+ /* fill PgDatabase from connstr */
+ bool parse_database(void *base, const char *name, const char *connstr)
+ {
+@@ -286,6 +356,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
+ 	char *datestyle = NULL;
+ 	char *timezone = NULL;
+ 	char *connect_query = NULL;
++	char *topology_query = NULL;
+ 	char *appname = NULL;
+ 
+ 	cv.value_p = &pool_mode;
+@@ -358,11 +429,26 @@ bool parse_database(void *base, const char *name, const char *connstr)
+ 				goto fail;
+ 			}
+ 		} else if (strcmp("connect_query", key) == 0) {
++			if (topology_query != NULL) {
++				log_error("connect_query cannot be used if topology_query is set");
++				goto fail;
++			}
+ 			connect_query = strdup(val);
+ 			if (!connect_query) {
+ 				log_error("out of memory");
+ 				goto fail;
+ 			}
++		} else if (strcmp("topology_query", key) == 0) {
++			if (connect_query != NULL) {
++				log_error("topology_query cannot be used if connect_query is set");
++				goto fail;
++			}
++			topology_query = strdup(val);
++			if (!topology_query) {
++				log_error("out of memory");
++				goto fail;
++			}
++			fast_switchover = true;
+ 		} else if (strcmp("application_name", key) == 0) {
+ 			appname = val;
+ 		} else {
+@@ -400,6 +486,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
+ 			changed = true;
+ 		} else if (!strings_equal(connect_query, db->connect_query)) {
+ 			changed = true;
++		} else if (!strings_equal(topology_query, db->topology_query)) {
++			changed = true;
+ 		} else if (!strings_equal(db->auth_dbname, auth_dbname)) {
+ 			changed = true;
+ 		}
+@@ -416,7 +504,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
+ 	db->pool_mode = pool_mode;
+ 	db->max_db_connections = max_db_connections;
+ 	free(db->connect_query);
++	free(db->topology_query);
+ 	db->connect_query = connect_query;
++	db->topology_query = topology_query;
+ 
+ 	if (!set_auth_dbname(db, auth_dbname))
+ 		goto fail;
+@@ -476,6 +566,13 @@ bool parse_database(void *base, const char *name, const char *connstr)
+ 	/* remember dbname */
+ 	db->dbname = (char *)msg->buf + dbname_ofs;
+ 
++	log_debug("creating pool for %s", db->name);
++	if (db->forced_user) {
++		PgPool *pool = get_pool(db, db->forced_user);
++		if (!pool)
++			fatal("pool could not be created for %s", db->name);
++	}
++
+ 	free(tmp_connstr);
+ 	return true;
+ fail:

--- a/src/main.c.diff
+++ b/src/main.c.diff
@@ -1,8 +1,24 @@
 diff --git a/src/main.c b/src/main.c
-index 89dbece..5736f9e 100644
+index 3fc1a0c..5736f9e 100644
 --- a/src/main.c
 +++ b/src/main.c
-@@ -173,6 +173,11 @@ int cf_log_disconnections;
+@@ -119,6 +119,7 @@ char *cf_auth_dbname;
+ 
+ int cf_max_client_conn;
+ int cf_default_pool_size;
++usec_t cf_polling_frequency;
+ int cf_min_pool_size;
+ int cf_res_pool_size;
+ usec_t cf_res_pool_timeout;
+@@ -130,6 +131,7 @@ int cf_server_reset_query_always;
+ char *cf_server_check_query;
+ usec_t cf_server_check_delay;
+ int cf_server_fast_close;
++usec_t cf_server_failed_delay;
+ int cf_server_round_robin;
+ int cf_disable_pqexec;
+ usec_t cf_dns_max_ttl;
+@@ -171,6 +173,11 @@ int cf_log_disconnections;
  int cf_log_pooler_errors;
  int cf_application_name_add_host;
  
@@ -14,7 +30,16 @@ index 89dbece..5736f9e 100644
  int cf_client_tls_sslmode;
  char *cf_client_tls_protocols;
  char *cf_client_tls_ca_file;
-@@ -284,6 +289,10 @@ CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
+@@ -273,6 +280,8 @@ CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),
+ CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),
+ CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
+ CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
++// in seconds. maps to 100ms by default.
++CF_ABS("polling_frequency", CF_TIME_USEC, cf_polling_frequency, 0, ".1"),
+ CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
+ CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
+ CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
+@@ -280,11 +289,17 @@ CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
  CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
  CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
  CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
@@ -25,3 +50,27 @@ index 89dbece..5736f9e 100644
  CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
  CF_ABS("server_check_delay", CF_TIME_USEC, cf_server_check_delay, 0, "30"),
  CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
+ CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
+ CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
++// allow backing off after switchover/failover. The delay to wait until reopening failed connections.
++CF_ABS("server_failed_delay", CF_TIME_USEC, cf_server_failed_delay, 0, "30"),
+ CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
+ CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
+ CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
+@@ -1040,12 +1055,16 @@ int main(int argc, char *argv[])
+ 	}
+ 
+ 	write_pidfile();
++	if (fast_switchover)
++		run_once_to_init();
+ 
+ 	log_info("process up: %s, libevent %s (%s), adns: %s, tls: %s", PACKAGE_STRING,
+ 		 event_get_version(), event_base_get_method(pgb_event_base), adns_get_backend(),
+ 		 tls_backend_version());
+ 
+ 	sd_notify(0, "READY=1");
++	if (fast_switchover)
++		cf_server_check_delay = 0;
+ 
+ 	/* main loop */
+ 	while (cf_shutdown < 2)

--- a/src/objects.c.diff
+++ b/src/objects.c.diff
@@ -1,0 +1,68 @@
+diff --git a/src/objects.c b/src/objects.c
+index ab662b8..bc497bb 100644
+--- a/src/objects.c
++++ b/src/objects.c
+@@ -643,14 +643,20 @@ PgPool *get_pool(PgDatabase *db, PgUser *user)
+ {
+ 	struct List *item;
+ 	PgPool *pool;
++	PgPool *global_writer = NULL;
+ 
+ 	if (!db || !user)
+ 		return NULL;
+ 
+ 	list_for_each(item, &user->pool_list) {
+ 		pool = container_of(item, PgPool, map_head);
+-		if (pool->db == db)
++		if (pool->db == db) {
++			global_writer = get_global_writer(pool);
++			if (global_writer)
++				return global_writer;
++
+ 			return pool;
++		}
+ 	}
+ 
+ 	return new_pool(db, user);
+@@ -854,6 +860,10 @@ bool life_over(PgSocket *server)
+ 	usec_t age = now - server->connect_time;
+ 	usec_t last_kill = now - pool->last_lifetime_disconnect;
+ 
++	// never close the pools when using fast switchovers
++	if (fast_switchover)
++		return false;
++
+ 	if (age < cf_server_lifetime)
+ 		return false;
+ 
+@@ -1589,6 +1599,8 @@ PgSocket *accept_client(int sock, bool is_unix)
+ /* client managed to authenticate, send welcome msg and accept queries */
+ bool finish_client_login(PgSocket *client)
+ {
++	PgPool *global_writer = get_global_writer(client->pool);
++
+ 	if (client->db->fake) {
+ 		if (cf_log_connections)
+ 			slog_info(client, "login failed: db=%s user=%s", client->db->name, client->login_user->name);
+@@ -1603,6 +1615,21 @@ bool finish_client_login(PgSocket *client)
+ 
+ 	switch (client->state) {
+ 	case CL_LOGIN:
++		if (client->pool->db->admin) {
++			log_debug("finish_client_login: admin_db: nothing to do");
++		} else if (!fast_switchover) {
++			log_debug("finish_client_login: not using fast switchovers");
++		} else if (!client->pool->db->topology_query) {
++			log_debug("finish_client_login: no topology query, so not using fast switchover");
++		} else if (global_writer) {
++			log_debug("finish_client_login: global writer is set, so let's use the cached value: %s", global_writer->db->name);
++			if (client->pool != global_writer && !set_pool(client, global_writer->db->name, client->login_user->name, client->login_user->passwd, true)) {
++				log_error("could not set pool to: %s", global_writer->db->name);
++				return false;
++			}
++		} else {
++			log_debug("finish_client_login: done...activating client");
++		}
+ 		change_client_state(client, CL_ACTIVE);
+ 	case CL_ACTIVE:
+ 		break;

--- a/src/pktbuf.c.diff
+++ b/src/pktbuf.c.diff
@@ -1,0 +1,42 @@
+diff --git a/src/pktbuf.c b/src/pktbuf.c
+index 7dfec56..c4a6080 100644
+--- a/src/pktbuf.c
++++ b/src/pktbuf.c
+@@ -65,6 +65,37 @@ PktBuf *pktbuf_dynamic(int start_len)
+ 	return buf;
+ }
+ 
++PktBuf *pktbuf_copy(PktBuf *orig)
++{
++	PktBuf *buf = zmalloc(sizeof(*orig));
++	if (!buf)
++		return NULL;
++
++	buf->ev = zmalloc(sizeof(*orig->ev));
++	if (!buf->ev) {
++		pktbuf_free(buf);
++		return NULL;
++	}
++	buf->buf = zmalloc(orig->buf_len);
++	if (!buf->buf) {
++		pktbuf_free(buf);
++		return NULL;
++	}
++
++	memcpy(buf->buf, orig->buf, orig->buf_len);
++	memcpy(buf->ev, orig->ev, sizeof(*orig->ev));
++
++	buf->buf_len = orig->buf_len;
++	buf->write_pos = orig->write_pos;
++	buf->pktlen_pos = orig->pktlen_pos;
++	buf->send_pos = orig->send_pos;
++	buf->failed = orig->failed;
++	buf->sending = orig->sending;
++	buf->fixed_buf = orig->fixed_buf;
++
++	return buf;
++}
++
+ void pktbuf_reset(struct PktBuf *pkt)
+ {
+ 	pkt->failed = false;

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,0 +1,204 @@
+diff --git a/src/server.c b/src/server.c
+index 46db05a..66729b8 100644
+--- a/src/server.c
++++ b/src/server.c
+@@ -22,6 +22,44 @@
+ 
+ #include "bouncer.h"
+ 
++/*
++* Returns the query data from the server. This must be freed.
++*/
++static char *query_data(PktHdr *pkt)
++{
++	uint16_t columns;
++	uint32_t length;
++	const char *data;
++	char *output;
++
++	if (!mbuf_get_uint16be(&pkt->data, &columns))
++	{
++		log_error("could not get packet column count");
++		return NULL;
++	}
++	if (!mbuf_get_uint32be(&pkt->data, &length))
++	{
++		log_error("could not get packet length");
++		return NULL;
++	}
++	if (!mbuf_get_chars(&pkt->data, length, &data))
++	{
++		log_error("could not get packet data");
++		return NULL;
++	}
++
++	output = strndup(data, length);
++	if (output == NULL) {
++		log_error("strdup: no mem in query_data");
++		return NULL;
++	}
++
++	log_debug("data from DataRow: %s, length: %d, strlen: %lu", output, length, strlen(output));
++
++	return output;
++}
++
++
+ static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
+ {
+ 	const char *key, *val;
+@@ -92,6 +130,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ 	SBuf *sbuf = &server->sbuf;
+ 	bool res = false;
+ 	const uint8_t *ckey;
++	char *data = NULL;
++	char *hostname = NULL;
+ 
+ 	if (incomplete_pkt(pkt)) {
+ 		disconnect_server(server, true, "partial pkt in login phase");
+@@ -102,11 +142,15 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ 	if (server->exec_on_connect) {
+ 		switch (pkt->type) {
+ 		case 'Z':
++		case 'D':
+ 		case 'S':	/* handle them below */
+ 			break;
+ 
+ 		case 'E':	/* log & ignore errors */
+ 			log_server_error("S: error while executing exec_on_query", pkt);
++			// require topology table to exist in the cluster if using
++			if (fast_switchover)
++				fatal("does the topology table exist?");
+ 			/* fallthrough */
+ 		default:	/* ignore rest */
+ 			sbuf_prepare_skip(sbuf, pkt->len);
+@@ -120,6 +164,38 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ 		disconnect_server(server, true, "unknown pkt from server");
+ 		break;
+ 
++	case 'D':       /* DataRow */
++		if (fast_switchover && server->pool->db->topology_query && server->pool->initial_writer_endpoint) {
++			data = query_data(pkt);
++			log_debug("got initial data: %s", data);
++
++			hostname = strdup(data);
++			if (hostname == NULL) {
++				log_error("strdup: no mem for hostname");
++				free(data);
++				return NULL;
++			}
++
++			if (!strtok(data, ".")) {
++				log_error("could not parse hostname from: %s", data);
++			} else {
++				PgPool *new_pool = new_pool_from_db(server->pool->db, data, hostname);
++				if (new_pool) {
++					new_pool->parent_pool = server->pool;
++					new_pool->parent_pool->global_writer = server->pool;
++					new_pool->db->topology_query = strdup(server->pool->db->topology_query);
++					launch_new_connection(new_pool, true);
++					server->pool->num_nodes++;
++				}
++			}
++
++			free(data);
++			free(hostname);
++		}
++
++		sbuf_prepare_skip(sbuf, pkt->len);
++		return true;
++		break;
+ 	case 'E':		/* ErrorResponse */
+ 		if (!server->pool->welcome_msg_ready)
+ 			kill_pool_logins_server_error(server->pool, pkt);
+@@ -152,7 +228,19 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+ 			if (!res)
+ 				disconnect_server(server, false, "exec_on_connect query failed");
+ 			break;
++		} else if (fast_switchover && server->pool->db->topology_query && server->pool->initial_writer_endpoint) {
++			server->exec_on_connect = true;
++			slog_debug(server, "server connect ok, send topology_query: %s", server->pool->db->topology_query);
++			SEND_generic(res, server, 'Q', "s", server->pool->db->topology_query);
++			if (!res)
++				disconnect_server(server, false, "exec_on_connect query failed");
++			break;
++		}
++
++		if (server->pool->db->topology_query && server->pool->initial_writer_endpoint && server->pool->num_nodes < 3) {
++			fatal("topology_query did not find at least 3 nodes to use DB: '%s'. Is the topology table populated with entries?", server->pool->db->name);
+ 		}
++		server->pool->initial_writer_endpoint = false;
+ 
+ 		/* login ok */
+ 		slog_debug(server, "server login ok, start accepting queries");
+@@ -358,6 +446,21 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 	/* data packets, there will be more coming */
+ 	case 'd':		/* CopyData(F/B) */
+ 	case 'D':		/* DataRow */
++		if (fast_switchover && checking_for_new_writer && server->state != SV_TESTED) {
++			char *data = query_data(pkt);
++			if (strcmp(data, "f") == 0) {
++				log_debug("handle_server_work: connected to writer (pg_is_in_recovery is '%s'): db_name %s", data, server->pool->db->name);
++
++				if (!server->pool->parent_pool) {
++					server->pool->parent_pool = server->pool;
++				}
++				server->pool->parent_pool->global_writer = server->pool;
++			} else {
++				log_debug("handle_server_work: connected to reader (pg_is_in_recovery is '%s'). db_name: %s, Must keep polling until next server.", data, server->pool->db->name);
++			}
++			checking_for_new_writer = false;
++			free(data);
++		}
+ 	case 't':		/* ParameterDescription */
+ 	case 'T':		/* RowDescription */
+ 		break;
+@@ -418,7 +521,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 			}
+ 		}
+ 	} else {
+-		if (server->state != SV_TESTED)
++		if (server->state != SV_TESTED && !server->pool->db->topology_query)
+ 			slog_warning(server,
+ 				     "got packet '%c' from server when not linked",
+ 				     pkt_desc(pkt));
+@@ -538,6 +641,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+ 	bool res = false;
+ 	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
+ 	PgPool *pool = server->pool;
++	PgPool *global_writer = get_global_writer(pool);
+ 	PktHdr pkt;
+ 	char infobuf[96];
+ 
+@@ -552,8 +656,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+ 	case SBUF_EV_RECV_FAILED:
+ 		if (server->state == SV_ACTIVE_CANCEL)
+ 			disconnect_server(server, false, "successfully sent cancel request");
+-		else
++		else {
++			if (global_writer)
++				clear_global_writer(pool);
++
++			// mark main pool as failed as well (the writer)
++			if (fast_switchover) {
++				pool->last_failed_time = get_cached_time();
++				pool->last_connect_failed = true;
++			}
++			checking_for_new_writer = false;
+ 			disconnect_server(server, false, "server conn crashed?");
++		}
+ 		break;
+ 	case SBUF_EV_SEND_FAILED:
+ 		disconnect_client(server->link, false, "unexpected eof");
+@@ -593,6 +707,11 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+ 		break;
+ 	case SBUF_EV_CONNECT_FAILED:
+ 		Assert(server->state == SV_LOGIN);
++		if (fast_switchover) {
++			pool->last_failed_time = get_cached_time();
++
++			checking_for_new_writer = false;
++		}
+ 		disconnect_server(server, false, "connect failed");
+ 		break;
+ 	case SBUF_EV_CONNECT_OK:

--- a/src/util.c.diff
+++ b/src/util.c.diff
@@ -1,0 +1,38 @@
+diff --git a/src/util.c b/src/util.c
+index 10bd2c3..6940c29 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -26,6 +26,33 @@
+ #include <usual/crypto/csrandom.h>
+ #include <usual/socket.h>
+ 
++PgPool *get_global_writer(PgPool *pool)
++{
++	if (!pool)
++		return NULL;
++
++	if (pool->global_writer)
++		return pool->global_writer;
++
++	if (!pool->parent_pool)
++		return NULL;
++
++	return pool->parent_pool->global_writer;
++}
++
++void clear_global_writer(PgPool *pool)
++{
++	if (pool->global_writer) {
++		pool->global_writer = NULL;
++		return;
++	}
++
++	if (!pool->parent_pool)
++		return;
++
++	pool->parent_pool->global_writer = NULL;
++}
++
+ int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstlen)
+ {
+ 	const struct PgSocket *sock = ctx;


### PR DESCRIPTION
* Introduce customer configurable topology_query. In order to get the topology from a cluster, the query should be
`topology_query='select endpoint from rds_topology'`. If this query is not set, then fast switchovers will not be enabled for the database.
* The topology_query is run every time PgBouncer is started as well as reloaded to discover all nodes in a cluster.
* Once the topology_query runs, connection pools are created to all nodes in a cluster. A query of select pg_is_in_recovery() is run by the proxy to discover who the writer in the cluster is and caches this node.
* A {switch,fail}over is discovered when the connection to the original writer are killed. PgBouncer pauses the client and serially polls the remaining nodes with `pg_is_in_recovery()` to discover the new writer. The new writer is cached for future connections.
* Introduced a config option, `server_failed_delay`, which specifies how long to wait between failed connection attempts to the downed writer to attempt a reconnect. The default is 30 seconds. This is to prevent infinite polling on the client.
* Once the downed writer is detected as active, a new connection pool is created to keep it available for the next switchover.
* If using fast switchovers, PgBouncer will override the server_lifetime option to never allow closing existing connections. This allows the connection pools to remain open indefinitely.
* A config option (polling_frequency) to determine how frequently to poll nodes during a {switch,fail}over has been added. Defaults to 100ms.
* Change server_check_delay to be set to 0 if fast_switchovers are enabled. This is to allow the polling logic to take place for fast switchovers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
