### PR TITLE
Add quality of life improvements for fast switchovers

### DIFF
--- a/doc/config.md.diff
+++ b/doc/config.md.diff
@@ -1,8 +1,8 @@
 diff --git a/doc/config.md b/doc/config.md
-index b181730..218cf38 100644
+index b181730..4872044 100644
 --- a/doc/config.md
 +++ b/doc/config.md
-@@ -131,6 +131,20 @@ the per-database configuration.
+@@ -131,6 +131,28 @@ the per-database configuration.
  
  Default: 20
  
@@ -20,6 +20,28 @@ index b181730..218cf38 100644
 +
 +Default: 30
 +
++### recreate_disconnected_pools
++
++If enabled, and [topology_query](#topology_query) is set for a pool, connections to the pools
++using the topology_query that have been closed will be automatically recreated during
++a failover.
++
++Default: 1 (enabled)
++
  ### min_pool_size
  
  Add more server connections to pool if below this number.
+@@ -1055,6 +1077,13 @@ Query to be executed after a connection is established, but before
+ allowing the connection to be used by any clients. If the query raises errors,
+ they are logged but ignored otherwise.
+ 
++### topology_query
++
++Query to be executed to determine the topology for a multi-node cluster. If set,
++PgBouncer will precreate connection pools to each node in the cluster.
++
++Example: topology_query='select endpoint from rds_tools.show_topology()'
++
+ ### pool_mode
+ 
+ Set the pool mode specific to this database. If not set,

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index f2c2bac..ddb07fc 100644
+index f2c2bac..ca7e7a0 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
 @@ -99,6 +99,11 @@ typedef struct ScramState ScramState;
@@ -43,15 +43,17 @@ index f2c2bac..ddb07fc 100644
  
  	struct PktBuf *startup_params; /* partial StartupMessage (without user) be sent to server */
  	const char *dbname;	/* server-side name, pointer to inside startup_msg */
-@@ -598,6 +612,7 @@ extern int cf_peer_id;
+@@ -598,7 +612,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
 +extern usec_t cf_polling_frequency;
  extern int cf_min_pool_size;
++extern int cf_recreate_disconnected_pools;
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
-@@ -615,6 +630,7 @@ extern int cf_server_reset_query_always;
+ extern int cf_max_db_connections;
+@@ -615,6 +631,7 @@ extern int cf_server_reset_query_always;
  extern char * cf_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
@@ -59,7 +61,7 @@ index f2c2bac..ddb07fc 100644
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -667,6 +683,11 @@ extern int cf_log_disconnections;
+@@ -667,6 +684,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 855a4c5..03ffc51 100644
+index 855a4c5..4ac80a8 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
 @@ -24,6 +24,9 @@
@@ -12,7 +12,7 @@ index 855a4c5..03ffc51 100644
  /* do full maintenance 3x per second */
  static struct timeval full_maint_period = {0, USEC / 3};
  static struct event full_maint_ev;
-@@ -125,21 +128,132 @@ void resume_all(void)
+@@ -125,21 +128,157 @@ void resume_all(void)
  	resume_pooler();
  }
  
@@ -87,6 +87,7 @@ index 855a4c5..03ffc51 100644
 +		update_client_pool(client, global_writer);
 +	} else if (pool->last_connect_failed) {
 +		bool found = false;
++		bool need_to_reconnect = true;
 +		reset_time_cache();
 +		now = get_cached_time();
 +		log_debug("launch_recheck: need to iterate pool list");
@@ -95,27 +96,32 @@ index 855a4c5..03ffc51 100644
 +			next_pool = container_of(item, PgPool, head);
 +
 +			if (!next_pool->parent_pool || next_pool->parent_pool != pool) {
++				log_debug("launch_recheck: no parent pool, skipping: %s", next_pool->db->name);
 +				continue;
 +			}
 +
-+			if (next_pool->last_connect_failed)
++			if (next_pool->last_connect_failed) {
++				log_debug("launch_recheck: last_connect_failed, skipping: %s", next_pool->db->name);
 +				continue;
++			}
++
++			need_to_reconnect = false;
 +
 +			if (next_pool->recently_checked) {
-+				log_debug("pool was recently checked, skipping: %s", next_pool->db->name);
++				log_debug("launch_recheck: pool was recently checked, skipping: %s", next_pool->db->name);
 +				continue;
 +			}
 +
 +			last_poll_time = next_pool->last_poll_time;
 +			difference_in_ms = (now - last_poll_time) / 1000;
-+			log_debug("last time checked for pool %s: now: %llu last: %llu, diff: %llu, polling_freq_max: %llu", next_pool->db->name, now, last_poll_time, difference_in_ms, cf_polling_frequency/1000);
++			log_debug("launch_recheck: last time checked for pool %s: now: %llu last: %llu, diff: %llu, polling_freq_max: %llu", next_pool->db->name, now, last_poll_time, difference_in_ms, cf_polling_frequency/1000);
 +
 +			if (difference_in_ms < polling_freq_in_ms) {
-+				log_debug("skipping because it's too soon for pool %s (%llu ms)", next_pool->db->name, difference_in_ms);
++				log_debug("launch_recheck: skipping because it's too soon for pool %s (%llu ms)", next_pool->db->name, difference_in_ms);
 +				continue;
 +			}
 +
-+			log_debug("found pool during iteration, setting to: %s", next_pool->db->name);
++			log_debug("launch_recheck: found pool during iteration, setting to: %s", next_pool->db->name);
 +
 +			found = update_client_pool(client, next_pool);
 +			if (!found)
@@ -124,7 +130,21 @@ index 855a4c5..03ffc51 100644
 +			break;
 +		}
 +
-+		if (!found) {
++		if (need_to_reconnect && cf_recreate_disconnected_pools) {
++			log_debug("launch_recheck: all pools failed, so need to try to reconnect to parents");
++			statlist_for_each(item, &pool_list) {
++				next_pool = container_of(item, PgPool, head);
++
++				if (!next_pool->parent_pool || next_pool->parent_pool != pool) {
++					continue;
++				}
++
++				log_debug("launch_recheck: establishing new connection to pool: %s", next_pool->db->name);
++				launch_new_connection(next_pool, /* evict_if_needed= */ true);
++			}
++
++			return;
++		} else if (!found) {
 +			log_debug("could not find alternate server, need to reset all pools");
 +			reset_recently_checked();
 +			/* drastically reduces switchover/failover time since we don't need to wait to get called again from per_loop_activate() */
@@ -141,16 +161,22 @@ index 855a4c5..03ffc51 100644
  	while (1) {
 -		server = first_socket(&pool->used_server_list);
 -		if (!server)
+-			return;
 +		server = first_socket(&client->pool->used_server_list);
 +		if (!server) {
-+			// need to reset
-+			client->pool->last_connect_failed = true;
- 			return;
++			log_debug("launch_recheck: could not find used_server for pool: %s", client->pool->db->name);
++
++			/* if a new connection pool was created because all three nodes in the cluster are down, servers are in the idle list instead of used list */
++			server = first_socket(&client->pool->idle_server_list);
++			if (!server) {
++				client->pool->last_connect_failed = true;
++				return;
++			}
 +		}
  		if (server->ready)
  			break;
  		disconnect_server(server, true, "idle server got dirty");
-@@ -155,12 +269,32 @@ static void launch_recheck(PgPool *pool)
+@@ -155,12 +294,32 @@ static void launch_recheck(PgPool *pool)
  	}
  
  	if (need_check) {
@@ -189,7 +215,7 @@ index 855a4c5..03ffc51 100644
  	} else {
  		/* make immediately available */
  		release_server(server);
-@@ -202,11 +336,22 @@ static void per_loop_activate(PgPool *pool)
+@@ -202,11 +361,22 @@ static void per_loop_activate(PgPool *pool)
  			--sv_tested;
  		} else if (sv_used > 0) {
  			/* ask for more connections to be tested */
@@ -214,7 +240,7 @@ index 855a4c5..03ffc51 100644
  			break;
  		}
  	}
-@@ -298,10 +443,7 @@ static int per_loop_wait_close(PgPool *pool)
+@@ -298,10 +468,7 @@ static int per_loop_wait_close(PgPool *pool)
  	return count;
  }
  
@@ -226,7 +252,7 @@ index 855a4c5..03ffc51 100644
  {
  	struct List *item;
  	PgPool *pool;
-@@ -310,6 +452,7 @@ void per_loop_maint(void)
+@@ -310,6 +477,7 @@ void per_loop_maint(void)
  	bool partial_pause = false;
  	bool partial_wait = false;
  	bool force_suspend = false;
@@ -234,7 +260,7 @@ index 855a4c5..03ffc51 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -321,13 +464,32 @@ void per_loop_maint(void)
+@@ -321,13 +489,32 @@ void per_loop_maint(void)
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -268,7 +294,7 @@ index 855a4c5..03ffc51 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -366,6 +528,27 @@ void per_loop_maint(void)
+@@ -366,6 +553,27 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
@@ -296,7 +322,15 @@ index 855a4c5..03ffc51 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -801,6 +984,7 @@ void kill_database(PgDatabase *db)
+@@ -472,6 +680,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+ 		} else if (server->state == SV_USED && !server->ready) {
+ 			disconnect_server(server, true, "SV_USED server got dirty");
+ 		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
++			   && (!pool->db && !pool->db->topology_query)
+ 			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
+ 			disconnect_server(server, true, "server idle timeout");
+ 		} else if (age >= cf_server_lifetime) {
+@@ -801,6 +1010,7 @@ void kill_database(PgDatabase *db)
  	if (db->forced_user)
  		slab_free(user_cache, db->forced_user);
  	free(db->connect_query);

--- a/src/main.c.diff
+++ b/src/main.c.diff
@@ -1,16 +1,18 @@
 diff --git a/src/main.c b/src/main.c
-index 3fc1a0c..5736f9e 100644
+index 3fc1a0c..f9164ee 100644
 --- a/src/main.c
 +++ b/src/main.c
-@@ -119,6 +119,7 @@ char *cf_auth_dbname;
+@@ -119,7 +119,9 @@ char *cf_auth_dbname;
  
  int cf_max_client_conn;
  int cf_default_pool_size;
 +usec_t cf_polling_frequency;
  int cf_min_pool_size;
++int cf_recreate_disconnected_pools;
  int cf_res_pool_size;
  usec_t cf_res_pool_timeout;
-@@ -130,6 +131,7 @@ int cf_server_reset_query_always;
+ int cf_max_db_connections;
+@@ -130,6 +132,7 @@ int cf_server_reset_query_always;
  char *cf_server_check_query;
  usec_t cf_server_check_delay;
  int cf_server_fast_close;
@@ -18,7 +20,7 @@ index 3fc1a0c..5736f9e 100644
  int cf_server_round_robin;
  int cf_disable_pqexec;
  usec_t cf_dns_max_ttl;
-@@ -171,6 +173,11 @@ int cf_log_disconnections;
+@@ -171,6 +174,11 @@ int cf_log_disconnections;
  int cf_log_pooler_errors;
  int cf_application_name_add_host;
  
@@ -30,7 +32,7 @@ index 3fc1a0c..5736f9e 100644
  int cf_client_tls_sslmode;
  char *cf_client_tls_protocols;
  char *cf_client_tls_ca_file;
-@@ -273,6 +280,8 @@ CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),
+@@ -273,18 +281,27 @@ CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),
  CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),
  CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
  CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
@@ -39,7 +41,8 @@ index 3fc1a0c..5736f9e 100644
  CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
  CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
  CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
-@@ -280,11 +289,17 @@ CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
+ CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
++CF_ABS("recreate_disconnected_pools", DEFER_OPS, cf_recreate_disconnected_pools, 0, "1"),
  CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
  CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
  CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
@@ -57,7 +60,7 @@ index 3fc1a0c..5736f9e 100644
  CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
  CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
  CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
-@@ -1040,12 +1055,16 @@ int main(int argc, char *argv[])
+@@ -1040,12 +1057,16 @@ int main(int argc, char *argv[])
  	}
  
  	write_pidfile();

--- a/src/objects.c.diff
+++ b/src/objects.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/objects.c b/src/objects.c
-index ab662b8..bc497bb 100644
+index ab662b8..e073699 100644
 --- a/src/objects.c
 +++ b/src/objects.c
 @@ -643,14 +643,20 @@ PgPool *get_pool(PgDatabase *db, PgUser *user)
@@ -29,7 +29,7 @@ index ab662b8..bc497bb 100644
  	usec_t last_kill = now - pool->last_lifetime_disconnect;
  
 +	// never close the pools when using fast switchovers
-+	if (fast_switchover)
++	if (pool->db && pool->db->topology_query)
 +		return false;
 +
  	if (age < cf_server_lifetime)


### PR DESCRIPTION
    Add quality of life improvements for fast switchovers

    - If a connection is idle, PgBouncer will close the associated pool
    (server_idle_timeout). Prevent closing these connections if the pool is
    using fast switchovers.

    - Fix when a server_lifetime elapses. Before, we would ignore
    server_idle_timeout if `fast_switchovers` was set globally. Instead,
    only ignore server_lifetime for a pool that has topology_query set,
    which is an indicator that it is using fast_switchovers.

    - Add more debugging statements in launch_recheck.

    - Add support for recreating connection pools automatically.
    If a switchover takes place, and all of the nodes in the cluster have
    disconnected for some reason (timeout or the cluster is down because of
    a sev2), PgBouncer would loop forever and not attempt to create new
    connections because new connections require DNS resolution (slow).
    Now, if no nodes in the cluster are available for connection, and the
    new config option `recreate_disconnected_pools` is set, try to recreate
    connection pools to the available nodes.

    - Add documentation about `topology_query` that was missing

    - Add documentation explaining new `recreate_disconnected_pools` setting