### PR TITLE
Add support for single quotes in queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The following uses default polling times and a `topology_query` configured to wo
 
 ```ini
 [databases]
-postgres = host=writer.cluster-cpkicoma6jyq.us-west-2.rds.amazonaws.com port=5432 user=master password=notaverysecurepassword dbname=postgres topology_query='select endpoint from rds_tools.show_topology()'
+postgres = host=writer.cluster-cpkicoma6jyq.us-west-2.rds.amazonaws.com port=5432 user=master password=notaverysecurepassword dbname=postgres topology_query='select endpoint from rds_tools.show_topology(\'pgbouncer\')'
 
 [pgbouncer]
 listen_addr = *

--- a/src/loader.c.diff
+++ b/src/loader.c.diff
@@ -1,8 +1,29 @@
 diff --git a/src/loader.c b/src/loader.c
-index 55f87a8..e6c8d2b 100644
+index 55f87a8..4db4b57 100644
 --- a/src/loader.c
 +++ b/src/loader.c
-@@ -260,6 +260,76 @@ fail:
+@@ -61,12 +61,20 @@ static char *cstr_unquote_value(char *p)
+ 	while (1) {
+ 		if (!*p)
+ 			return NULL;
++		/* Support escaping single quotes */
++		if (p[0] == '\\') {
++			if (p[1] == '\'') {
++				p++;
++				goto increment;
++			}
++		}
+ 		if (p[0] == '\'') {
+ 			if (p[1] == '\'')
+ 				p++;
+ 			else
+ 				break;
+ 		}
++increment:
+ 		*s++ = *p++;
+ 	}
+ 	/* terminate actual value */
+@@ -260,6 +268,76 @@ fail:
  	free(tmp_connstr);
  	return false;
  }
@@ -79,7 +100,7 @@ index 55f87a8..e6c8d2b 100644
  /* fill PgDatabase from connstr */
  bool parse_database(void *base, const char *name, const char *connstr)
  {
-@@ -286,6 +356,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -286,6 +364,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	char *datestyle = NULL;
  	char *timezone = NULL;
  	char *connect_query = NULL;
@@ -87,7 +108,7 @@ index 55f87a8..e6c8d2b 100644
  	char *appname = NULL;
  
  	cv.value_p = &pool_mode;
-@@ -358,11 +429,26 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -358,11 +437,26 @@ bool parse_database(void *base, const char *name, const char *connstr)
  				goto fail;
  			}
  		} else if (strcmp("connect_query", key) == 0) {
@@ -114,7 +135,7 @@ index 55f87a8..e6c8d2b 100644
  		} else if (strcmp("application_name", key) == 0) {
  			appname = val;
  		} else {
-@@ -400,6 +486,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -400,6 +494,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
  			changed = true;
  		} else if (!strings_equal(connect_query, db->connect_query)) {
  			changed = true;
@@ -123,7 +144,7 @@ index 55f87a8..e6c8d2b 100644
  		} else if (!strings_equal(db->auth_dbname, auth_dbname)) {
  			changed = true;
  		}
-@@ -416,7 +504,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -416,7 +512,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	db->pool_mode = pool_mode;
  	db->max_db_connections = max_db_connections;
  	free(db->connect_query);
@@ -133,7 +154,7 @@ index 55f87a8..e6c8d2b 100644
  
  	if (!set_auth_dbname(db, auth_dbname))
  		goto fail;
-@@ -476,6 +566,13 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -476,6 +574,13 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	/* remember dbname */
  	db->dbname = (char *)msg->buf + dbname_ofs;
  


### PR DESCRIPTION
`topology_query` and `connect_query` now support single quotes. Update README as well for suggested topology_query.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
