### PR TITLE
Refresh topology on switchover

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,12 @@ $ docker run -v $(pwd)/pgbouncer.ini:/home/pgbouncer/pgbouncer.ini -v $(pwd)/use
 Notice in the output above that connection pools are precreated to your three nodes (`test-instance-{1,2,3}`). Your PgBouncer container is now
 ready to provide fast switchovers.
 
+Optionally, start PgBouncer in verbose mode by setting the `VERBOSE` environment variable
+
+```sh
+$ docker run -e VERBOSE="-vv" ...
+```
+
 Connect to your instance
 
 ```sh

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,5 +1,5 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index f2c2bac..ca7e7a0 100644
+index f2c2bac..6f45879 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
 @@ -99,6 +99,11 @@ typedef struct ScramState ScramState;
@@ -14,7 +14,7 @@ index f2c2bac..ca7e7a0 100644
  #include "util.h"
  #include "iobuf.h"
  #include "sbuf.h"
-@@ -374,12 +379,20 @@ struct PgPool {
+@@ -374,12 +379,31 @@ struct PgPool {
  
  	/* if last connect to server failed, there should be delay before next */
  	usec_t last_connect_time;
@@ -24,9 +24,21 @@ index f2c2bac..ca7e7a0 100644
  	bool last_login_failed:1;
  
  	bool welcome_msg_ready:1;
+-
 +	bool recently_checked:1; // should be set once checking starts. If all pools have this set, they need to be unset so we can loop again.
 +	bool initial_writer_endpoint:1; // used to indicate a configured writer when starting PgBouncer. Used for getting the topology of the cluster associated with the writer.
- 
++	bool refresh_topology:1; // after a new writer is found, indicate that we need to refresh the topology.
++	/*
++	 * Used to indicate that DataRow, CommandComplete, and ReadyForQuery should be discarded.
++	 * This is for the case where the topology has to be refreshed, but the data should not be
++	 * sent to the client.
++	 * 
++	 * Once the ReadyForQuery is received, all topology data has been discarded and regular
++	 * client server communications can resume.
++	*/
++	bool collect_datarows:1; 
++	bool checking_for_new_writer:1; // this is linked with server and client so we can communicate when polling is truly done. Used to only allow checking for one node a time.
++
 +	uint16_t num_nodes;
  	uint16_t rrcounter;		/* round-robin counter */
 +
@@ -35,7 +47,7 @@ index f2c2bac..ca7e7a0 100644
  };
  
  /*
-@@ -466,6 +479,7 @@ struct PgDatabase {
+@@ -466,6 +490,7 @@ struct PgDatabase {
  	int pool_mode;		/* pool mode for this database */
  	int max_db_connections;	/* max server connections between all pools */
  	char *connect_query;	/* startup commands to send to server after connect */
@@ -43,7 +55,7 @@ index f2c2bac..ca7e7a0 100644
  
  	struct PktBuf *startup_params; /* partial StartupMessage (without user) be sent to server */
  	const char *dbname;	/* server-side name, pointer to inside startup_msg */
-@@ -598,7 +612,9 @@ extern int cf_peer_id;
+@@ -598,7 +623,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
@@ -53,7 +65,7 @@ index f2c2bac..ca7e7a0 100644
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
  extern int cf_max_db_connections;
-@@ -615,6 +631,7 @@ extern int cf_server_reset_query_always;
+@@ -615,6 +642,7 @@ extern int cf_server_reset_query_always;
  extern char * cf_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
@@ -61,7 +73,7 @@ index f2c2bac..ca7e7a0 100644
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -667,6 +684,11 @@ extern int cf_log_disconnections;
+@@ -667,6 +695,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/include/objects.h.diff
+++ b/include/objects.h.diff
@@ -1,13 +1,12 @@
 diff --git a/include/objects.h b/include/objects.h
-index 7f64ce1..1360807 100644
+index 7f64ce1..9737490 100644
 --- a/include/objects.h
 +++ b/include/objects.h
-@@ -32,6 +32,8 @@ extern struct Slab *peer_pool_cache;
+@@ -32,6 +32,7 @@ extern struct Slab *peer_pool_cache;
  extern struct Slab *pool_cache;
  extern struct Slab *user_cache;
  extern struct Slab *iobuf_cache;
 +extern bool fast_switchover;
-+extern bool checking_for_new_writer; // this is linked with server and client so we can communicate when polling is truly done. Used to only allow checking for one node a time.
  
  PgDatabase *find_peer(int peer_id);
  PgDatabase *find_database(const char *name);

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,18 +1,17 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 855a4c5..4ac80a8 100644
+index 855a4c5..3ae5bc2 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
-@@ -24,6 +24,9 @@
+@@ -24,6 +24,8 @@
  
  #include <usual/slab.h>
  
 +bool fast_switchover = false;
-+bool checking_for_new_writer = false;
 +
  /* do full maintenance 3x per second */
  static struct timeval full_maint_period = {0, USEC / 3};
  static struct event full_maint_ev;
-@@ -125,21 +128,157 @@ void resume_all(void)
+@@ -125,21 +127,157 @@ void resume_all(void)
  	resume_pooler();
  }
  
@@ -75,11 +74,6 @@ index 855a4c5..4ac80a8 100644
 +
 +	log_debug("launch_recheck: for db: %s, global_writer? %s", pool->db->name, global_writer ? global_writer->db->name : "no global_writer");
 +
-+	if (checking_for_new_writer) {
-+		log_debug("launch_recheck: checking_for_new_writer is true so a node is being checked if it is a writer already, skipping");
-+		return;
-+	}
-+
 +	if (!pool->db->topology_query) {
 +		log_debug("launch_recheck: no topology_query for this pool, so proceeding without cache");
 +	} else if (global_writer) {
@@ -106,6 +100,11 @@ index 855a4c5..4ac80a8 100644
 +			}
 +
 +			need_to_reconnect = false;
++
++			if (next_pool->checking_for_new_writer) {
++				log_debug("launch_recheck: checking_for_new_writer is true for node '%s', can't run another recovery check until done.", next_pool->db->name);
++				return;
++			}
 +
 +			if (next_pool->recently_checked) {
 +				log_debug("launch_recheck: pool was recently checked, skipping: %s", next_pool->db->name);
@@ -176,7 +175,7 @@ index 855a4c5..4ac80a8 100644
  		if (server->ready)
  			break;
  		disconnect_server(server, true, "idle server got dirty");
-@@ -155,12 +294,32 @@ static void launch_recheck(PgPool *pool)
+@@ -155,12 +293,32 @@ static void launch_recheck(PgPool *pool)
  	}
  
  	if (need_check) {
@@ -187,7 +186,7 @@ index 855a4c5..4ac80a8 100644
 -		if (!res)
 -			disconnect_server(server, false, "test query failed");
 +		if (fast_switchover && pool->db->topology_query && !global_writer) {
-+			checking_for_new_writer = true;
++			client->pool->checking_for_new_writer = true;
 +			q = strdup("select pg_is_in_recovery()");
 +			if (q == NULL) {
 +				log_error("strdup: no mem for pg_is_in_recovery()");
@@ -215,7 +214,7 @@ index 855a4c5..4ac80a8 100644
  	} else {
  		/* make immediately available */
  		release_server(server);
-@@ -202,11 +361,22 @@ static void per_loop_activate(PgPool *pool)
+@@ -202,11 +360,22 @@ static void per_loop_activate(PgPool *pool)
  			--sv_tested;
  		} else if (sv_used > 0) {
  			/* ask for more connections to be tested */
@@ -240,7 +239,7 @@ index 855a4c5..4ac80a8 100644
  			break;
  		}
  	}
-@@ -298,10 +468,7 @@ static int per_loop_wait_close(PgPool *pool)
+@@ -298,10 +467,7 @@ static int per_loop_wait_close(PgPool *pool)
  	return count;
  }
  
@@ -252,7 +251,7 @@ index 855a4c5..4ac80a8 100644
  {
  	struct List *item;
  	PgPool *pool;
-@@ -310,6 +477,7 @@ void per_loop_maint(void)
+@@ -310,6 +476,7 @@ void per_loop_maint(void)
  	bool partial_pause = false;
  	bool partial_wait = false;
  	bool force_suspend = false;
@@ -260,7 +259,7 @@ index 855a4c5..4ac80a8 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -321,13 +489,32 @@ void per_loop_maint(void)
+@@ -321,13 +488,32 @@ void per_loop_maint(void)
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -294,7 +293,7 @@ index 855a4c5..4ac80a8 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -366,6 +553,27 @@ void per_loop_maint(void)
+@@ -366,6 +552,27 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
@@ -322,15 +321,15 @@ index 855a4c5..4ac80a8 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -472,6 +680,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+@@ -472,6 +679,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
  		} else if (server->state == SV_USED && !server->ready) {
  			disconnect_server(server, true, "SV_USED server got dirty");
  		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
-+			   && (!pool->db && !pool->db->topology_query)
++			   && (pool->db && !pool->db->topology_query)
  			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
  			disconnect_server(server, true, "server idle timeout");
  		} else if (age >= cf_server_lifetime) {
-@@ -801,6 +1010,7 @@ void kill_database(PgDatabase *db)
+@@ -801,6 +1009,7 @@ void kill_database(PgDatabase *db)
  	if (db->forced_user)
  		slab_free(user_cache, db->forced_user);
  	free(db->connect_query);

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/server.c b/src/server.c
-index 46db05a..66729b8 100644
+index 46db05a..f53d3b6 100644
 --- a/src/server.c
 +++ b/src/server.c
 @@ -22,6 +22,44 @@
@@ -111,7 +111,7 @@ index 46db05a..66729b8 100644
  	case 'E':		/* ErrorResponse */
  		if (!server->pool->welcome_msg_ready)
  			kill_pool_logins_server_error(server->pool, pkt);
-@@ -152,7 +228,19 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,8 +228,20 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
@@ -122,20 +122,65 @@ index 46db05a..66729b8 100644
 +			if (!res)
 +				disconnect_server(server, false, "exec_on_connect query failed");
 +			break;
-+		}
-+
-+		if (server->pool->db->topology_query && server->pool->initial_writer_endpoint && server->pool->num_nodes < 3) {
-+			fatal("topology_query did not find at least 3 nodes to use DB: '%s'. Is the topology table populated with entries?", server->pool->db->name);
  		}
-+		server->pool->initial_writer_endpoint = false;
  
++		if (server->pool->db->topology_query && server->pool->initial_writer_endpoint && server->pool->num_nodes < 2) {
++			fatal("topology_query did not find at least 2 nodes to use fast switchovers in DB: '%s'. Is the topology table populated with entries?", server->pool->db->name);
++		}
++		server->pool->initial_writer_endpoint = false;
++
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
-@@ -358,6 +446,21 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 		server->ready = true;
+@@ -250,6 +338,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 	SBuf *sbuf = &server->sbuf;
+ 	PgSocket *client = server->link;
+ 	bool async_response = false;
++	bool res = false;
+ 
+ 	Assert(!server->pool->db->admin);
+ 
+@@ -261,6 +350,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 
+ 	/* pooling decisions will be based on this packet */
+ 	case 'Z':		/* ReadyForQuery */
++		/*
++		 * Discard topology data without sending to the client is finished. Resume regular
++		 * client/server communication.
++		 */
++		if (fast_switchover && server->pool->db->topology_query && server->pool->collect_datarows) {
++			server->pool->collect_datarows = false;
++			sbuf_prepare_skip(sbuf, pkt->len);
++			return true;
++		}
+ 
+ 		/* if partial pkt, wait */
+ 		if (!mbuf_get_char(&pkt->data, &state))
+@@ -318,6 +416,13 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+ 		}
+ 		/* fallthrough */
+ 	case 'C':		/* CommandComplete */
++		/*
++		 * In the process of discarding topology data without sending to the client.
++		 */
++		if (server->pool->collect_datarows) {
++			sbuf_prepare_skip(sbuf, pkt->len);
++			return true;
++		}
+ 
+ 		/* ErrorResponse and CommandComplete show end of copy mode */
+ 		if (server->copy_mode) {
+@@ -358,6 +463,29 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
  	case 'd':		/* CopyData(F/B) */
  	case 'D':		/* DataRow */
-+		if (fast_switchover && checking_for_new_writer && server->state != SV_TESTED) {
++		/*
++		 * These are the rows returned from the topology query that are discarded.
++		 */
++		if (server->pool->collect_datarows) {
++			sbuf_prepare_skip(sbuf, pkt->len);
++			return true;
++		} else if (fast_switchover && server->pool->checking_for_new_writer && server->state != SV_TESTED) {
 +			char *data = query_data(pkt);
 +			if (strcmp(data, "f") == 0) {
 +				log_debug("handle_server_work: connected to writer (pg_is_in_recovery is '%s'): db_name %s", data, server->pool->db->name);
@@ -144,16 +189,18 @@ index 46db05a..66729b8 100644
 +					server->pool->parent_pool = server->pool;
 +				}
 +				server->pool->parent_pool->global_writer = server->pool;
++				// new writer has been found, so indicate that we need to refresh the topology.
++				server->pool->refresh_topology = true;
 +			} else {
 +				log_debug("handle_server_work: connected to reader (pg_is_in_recovery is '%s'). db_name: %s, Must keep polling until next server.", data, server->pool->db->name);
 +			}
-+			checking_for_new_writer = false;
++			server->pool->checking_for_new_writer = false;
 +			free(data);
 +		}
  	case 't':		/* ParameterDescription */
  	case 'T':		/* RowDescription */
  		break;
-@@ -418,7 +521,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -418,13 +546,26 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
@@ -162,7 +209,26 @@ index 46db05a..66729b8 100644
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
-@@ -538,6 +641,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+ 		sbuf_prepare_skip(sbuf, pkt->len);
+ 	}
+ 
++	/*
++	 * pg_is_in_recovery() finished since we received a ReadyForQuery and refresh_topology is set.
++	 * Mark the pool as needing to collect data rows and send the topology query to the writer.
++	 */
++	if (server->pool->refresh_topology && pkt->type == 'Z') {
++		server->pool->collect_datarows = true;
++		server->pool->refresh_topology = false;
++
++		SEND_generic(res, server, 'Q', "s", server->pool->db->topology_query);
++		if (!res)
++			disconnect_server(server, false, "exec_on_connect query failed");
++	}
++
+ 	return true;
+ }
+ 
+@@ -538,6 +679,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -170,7 +236,7 @@ index 46db05a..66729b8 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -552,8 +656,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -552,8 +694,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -183,21 +249,20 @@ index 46db05a..66729b8 100644
 +			if (fast_switchover) {
 +				pool->last_failed_time = get_cached_time();
 +				pool->last_connect_failed = true;
++				server->pool->checking_for_new_writer = false;
 +			}
-+			checking_for_new_writer = false;
  			disconnect_server(server, false, "server conn crashed?");
 +		}
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -593,6 +707,11 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -593,6 +745,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);
 +		if (fast_switchover) {
 +			pool->last_failed_time = get_cached_time();
-+
-+			checking_for_new_writer = false;
++			server->pool->checking_for_new_writer = false;
 +		}
  		disconnect_server(server, false, "connect failed");
  		break;


### PR DESCRIPTION
Bug fixes for fast switchovers and change in topology_query behavior

- Allow topology as long as there are at least two nodes
    It was on oversight by me to enforce 3 nodes in the cluster. What if we
    use this for MAZ in the future or for a cluster with N nodes?

- Send the topology query every time a switchover occurs
    We use this to ensure we get a better accounting of the PgBouncer usage
    metric.

- Remove global checking for new writer
    This fixes the theoretical case where one DB is switching over, but
    others are operating fine. Setting `checking_for_new_writer` globally
    would block all DBs. Instead, we want to only block the DB with pools
    that are switching over.

-  Fix backwards logic in check_unused_servers
    Found this when running the in-repo regression tests. If the
    topology_query is not set, then continue with the other checks in the
    function. The original check was ensuring that pool->db was not NULL
    before accessing topology_query.

- Add back README entry that was deleted by accident