### PR TITLE
Only run server_check_query if need_check is set

### DIFF
--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 855a4c5..3ae5bc2 100644
+index 855a4c5..1e02db8 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
 @@ -24,6 +24,8 @@
@@ -11,7 +11,7 @@ index 855a4c5..3ae5bc2 100644
  /* do full maintenance 3x per second */
  static struct timeval full_maint_period = {0, USEC / 3};
  static struct event full_maint_ev;
-@@ -125,21 +127,157 @@ void resume_all(void)
+@@ -125,21 +127,158 @@ void resume_all(void)
  	resume_pooler();
  }
  
@@ -61,6 +61,7 @@ index 855a4c5..3ae5bc2 100644
  {
 -	const char *q = cf_server_check_query;
 +	char *q = cf_server_check_query;
++	char *recovery_query = NULL;
  	bool need_check = true;
  	PgSocket *server;
  	bool res = true;
@@ -175,46 +176,39 @@ index 855a4c5..3ae5bc2 100644
  		if (server->ready)
  			break;
  		disconnect_server(server, true, "idle server got dirty");
-@@ -155,12 +293,32 @@ static void launch_recheck(PgPool *pool)
+@@ -154,6 +293,31 @@ static void launch_recheck(PgPool *pool)
+ 			need_check = false;
  	}
  
- 	if (need_check) {
--		/* send test query, wait for result */
--		slog_debug(server, "P: checking: %s", q);
--		change_server_state(server, SV_TESTED);
--		SEND_generic(res, server, 'Q', "s", q);
--		if (!res)
--			disconnect_server(server, false, "test query failed");
-+		if (fast_switchover && pool->db->topology_query && !global_writer) {
++	if (fast_switchover && pool->db->topology_query) {
++		if (!global_writer) {
 +			client->pool->checking_for_new_writer = true;
-+			q = strdup("select pg_is_in_recovery()");
-+			if (q == NULL) {
++			recovery_query = strdup("select pg_is_in_recovery()");
++			if (recovery_query == NULL) {
 +				log_error("strdup: no mem for pg_is_in_recovery()");
 +				return;
 +			}
-+			slog_debug(server, "P: checking: %s (not done polling)", q);
-+			SEND_generic(res, server, 'Q', "s", q);
++			slog_debug(server, "P: checking: %s (not done polling)", recovery_query);
++			SEND_generic(res, server, 'Q', "s", recovery_query);
 +			if (!res)
 +				disconnect_server(server, false, "pg_is_in_recovery() query failed");
-+			free(q);
++			free(recovery_query);
++			return;
 +		} else {
 +			reset_recently_checked();
-+
-+			slog_debug(server, "P: checking: %s (done polling)", q);
 +			change_server_state(server, SV_TESTED);
-+			SEND_generic(res, server, 'Q', "s", q);
-+			if (!res)
-+				disconnect_server(server, false, "test query failed");
 +
 +			/* reactivate paused clients that never finished logging in */
 +			if (client->state == CL_WAITING_LOGIN || client->state == CL_WAITING) {
 +				activate_client(client);
 +			}
 +		}
- 	} else {
- 		/* make immediately available */
- 		release_server(server);
-@@ -202,11 +360,22 @@ static void per_loop_activate(PgPool *pool)
++	}
++
+ 	if (need_check) {
+ 		/* send test query, wait for result */
+ 		slog_debug(server, "P: checking: %s", q);
+@@ -202,11 +366,22 @@ static void per_loop_activate(PgPool *pool)
  			--sv_tested;
  		} else if (sv_used > 0) {
  			/* ask for more connections to be tested */
@@ -239,7 +233,7 @@ index 855a4c5..3ae5bc2 100644
  			break;
  		}
  	}
-@@ -298,10 +467,7 @@ static int per_loop_wait_close(PgPool *pool)
+@@ -298,10 +473,7 @@ static int per_loop_wait_close(PgPool *pool)
  	return count;
  }
  
@@ -251,7 +245,7 @@ index 855a4c5..3ae5bc2 100644
  {
  	struct List *item;
  	PgPool *pool;
-@@ -310,6 +476,7 @@ void per_loop_maint(void)
+@@ -310,6 +482,7 @@ void per_loop_maint(void)
  	bool partial_pause = false;
  	bool partial_wait = false;
  	bool force_suspend = false;
@@ -259,7 +253,7 @@ index 855a4c5..3ae5bc2 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -321,13 +488,32 @@ void per_loop_maint(void)
+@@ -321,13 +494,32 @@ void per_loop_maint(void)
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -293,7 +287,7 @@ index 855a4c5..3ae5bc2 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -366,6 +552,27 @@ void per_loop_maint(void)
+@@ -366,6 +558,27 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
@@ -321,7 +315,7 @@ index 855a4c5..3ae5bc2 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -472,6 +679,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+@@ -472,6 +685,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
  		} else if (server->state == SV_USED && !server->ready) {
  			disconnect_server(server, true, "SV_USED server got dirty");
  		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
@@ -329,7 +323,7 @@ index 855a4c5..3ae5bc2 100644
  			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
  			disconnect_server(server, true, "server idle timeout");
  		} else if (age >= cf_server_lifetime) {
-@@ -801,6 +1009,7 @@ void kill_database(PgDatabase *db)
+@@ -801,6 +1015,7 @@ void kill_database(PgDatabase *db)
  	if (db->forced_user)
  		slab_free(user_cache, db->forced_user);
  	free(db->connect_query);

--- a/src/main.c.diff
+++ b/src/main.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/main.c b/src/main.c
-index 3fc1a0c..f9164ee 100644
+index 3fc1a0c..dba92f2 100644
 --- a/src/main.c
 +++ b/src/main.c
 @@ -119,7 +119,9 @@ char *cf_auth_dbname;
@@ -60,7 +60,7 @@ index 3fc1a0c..f9164ee 100644
  CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
  CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
  CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
-@@ -1040,12 +1057,16 @@ int main(int argc, char *argv[])
+@@ -1040,6 +1057,8 @@ int main(int argc, char *argv[])
  	}
  
  	write_pidfile();
@@ -69,11 +69,3 @@ index 3fc1a0c..f9164ee 100644
  
  	log_info("process up: %s, libevent %s (%s), adns: %s, tls: %s", PACKAGE_STRING,
  		 event_get_version(), event_base_get_method(pgb_event_base), adns_get_backend(),
- 		 tls_backend_version());
- 
- 	sd_notify(0, "READY=1");
-+	if (fast_switchover)
-+		cf_server_check_delay = 0;
- 
- 	/* main loop */
- 	while (cf_shutdown < 2)


### PR DESCRIPTION
No longer unconditionally enable `need_check` for fast switchovers. It has a huge performance penalty to run the `select 1` on each query.

Before:

```
$ pgbench -c 500 -T 60 postgres -p 5432 -U test -j 2 -S -h localhost
pgbench (15.0, server 15.4)
starting vacuum...end.
transaction type: <builtin: select only>
scaling factor: 1
query mode: simple
number of clients: 500
number of threads: 2
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 303649
number of failed transactions: 0 (0.000%)
latency average = 83.496 ms
initial connection time = 9472.173 ms
tps = 5988.309259 (without initial connection time)
```

After:

```
$ pgbench -c 500 -T 60 postgres -p 5432 -U test -j 2 -S -h localhost
pgbench (15.0, server 15.4)
starting vacuum...end.
transaction type: <builtin: select only>
scaling factor: 1
query mode: simple
number of clients: 500
number of threads: 2
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 576140
number of failed transactions: 0 (0.000%)
latency average = 44.274 ms
initial connection time = 9096.701 ms
tps = 11293.192236 (without initial connection time)
```
