### PR TITLE
Upgrade fast switchover to latest version of pgbouncer(1.24)

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -7,7 +7,10 @@ RUN yum install -y tar net-tools curl vim unzip less libevent-devel openssl-deve
 RUN ARCH="" && if [ "$(uname -m)" = "x86_64" ]; then ARCH='amd64'; else ARCH='arm64'; fi && export ${ARCH} && \
     wget https://github.com/jgm/pandoc/releases/download/3.1.6.2/pandoc-3.1.6.2-linux-${ARCH}.tar.gz && \
     tar xvzf ./pandoc-3.1.6.2-linux-${ARCH}.tar.gz --strip-components 1 -C /usr/local
-RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.19" && \
+RUN git clone https://github.com/pgbouncer/pgbouncer.git && \
+    cd pgbouncer && \
+    git checkout -b pgbouncer-1.24 tags/pgbouncer_1_24_1 && \
+    cd .. && \
     git clone https://github.com/awslabs/pgbouncer-rr-patch.git && \
     cd pgbouncer-rr-patch && \
     ./install-pgbouncer-rr-patch.sh ../pgbouncer && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,10 @@
 FROM $BASE_IMAGE
 USER root
 
-RUN git clone https://github.com/pgbouncer/pgbouncer.git --branch "$PGB_GITHUB_BRANCH" && \
+RUN git clone https://github.com/pgbouncer/pgbouncer.git && \
+    cd pgbouncer && \
+    git checkout -b "$PGB_GITHUB_BRANCH" tags/pgbouncer_1_24_1 && \
+    cd .. && \
     git clone https://github.com/awslabs/pgbouncer-fast-switchover.git --branch "ci-build" && \
     cd pgbouncer-fast-switchover && \
     ./install-pgbouncer-rr-patch.sh ../pgbouncer && \

--- a/Makefile.diff
+++ b/Makefile.diff
@@ -1,18 +1,18 @@
 diff --git a/Makefile b/Makefile
-index 00773da..981e06a 100644
+index f417ef2..33d9534 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -21,6 +21,9 @@ pgbouncer_SOURCES = \
+@@ -23,6 +23,9 @@ pgbouncer_SOURCES = \
  	src/server.c \
  	src/stats.c \
  	src/system.c \
-+        src/pycall.c \
-+        src/route_connection.c \
-+        src/rewrite_query.c \
++	src/pycall.c \
++	src/route_connection.c \
++	src/rewrite_query.c \
  	src/takeover.c \
  	src/util.c \
  	src/varcache.c \
-@@ -47,6 +50,9 @@ pgbouncer_SOURCES = \
+@@ -53,6 +56,9 @@ pgbouncer_SOURCES = \
  	include/server.h \
  	include/stats.h \
  	include/system.h \
@@ -22,17 +22,17 @@ index 00773da..981e06a 100644
  	include/takeover.h \
  	include/util.h \
  	include/varcache.h \
-@@ -59,7 +65,8 @@ pgbouncer_SOURCES = \
- 	include/common/unicode_norm.h \
- 	include/common/unicode_norm_table.h
+@@ -69,7 +75,8 @@ pgbouncer_SOURCES = \
+	include/common/uthash_lowercase.h
  
+ UTHASH = uthash
 -pgbouncer_CPPFLAGS = -Iinclude $(CARES_CFLAGS) $(LIBEVENT_CFLAGS) $(TLS_CPPFLAGS)
 +python_CPPFLAGS = -I/usr/include/python3.9 -I/usr/include/python3.9
 +pgbouncer_CPPFLAGS = -Iinclude $(CARES_CFLAGS) $(LIBEVENT_CFLAGS) $(TLS_CPPFLAGS) $(python_CPPFLAGS)
+ pgbouncer_CPPFLAGS += -I$(UTHASH)/src
  
  # include libusual sources directly
- AM_FEATURES = libusual
-@@ -71,6 +78,8 @@ dist_doc_DATA = README.md NEWS.md \
+@@ -82,6 +89,8 @@ dist_doc_DATA = README.md NEWS.md \
  	etc/pgbouncer.ini \
  	etc/pgbouncer.service \
  	etc/pgbouncer.socket \
@@ -41,9 +41,9 @@ index 00773da..981e06a 100644
  	etc/userlist.txt
  
  DISTCLEANFILES = config.mak config.status lib/usual/config.h config.log
-@@ -98,8 +107,10 @@ LIBUSUAL_DIST = $(filter-out %/config.h, $(sort $(wildcard \
- 		lib/README lib/COPYRIGHT \
- 		lib/find_modules.sh )))
+@@ -113,8 +122,10 @@ LIBUSUAL_DIST = $(filter-out %/config.h, $(sort $(wildcard \
+ UTHASH_DIST = $(UTHASH)/src/uthash.h \
+               $(UTHASH)/LICENSE
  
 +python_LDFLAGS = -lpthread -ldl -lutil -lm -lpython3.9 -Xlinker -export-dynamic
  pgbouncer_LDFLAGS := $(TLS_LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -219,8 +219,11 @@ Download and install pgbouncer-fast-switchover by running the following commands
 # install required packages - see https://github.com/pgbouncer/pgbouncer#building
 sudo yum install libevent-devel openssl-devel python-devel libtool git patch make -y
 
-# download the latest tested pgbouncer distribution - 1.19
-git clone https://github.com/pgbouncer/pgbouncer.git --branch "stable-1.19"
+# download the latest tested pgbouncer distribution - 1.24
+git clone https://github.com/pgbouncer/pgbouncer.git
+cd pgbouncer
+git checkout -b pgbouncer-1.24 tags/pgbouncer_1_24_1
+cd ..
 
 # download pgbouncer-fast-switchover extensions
 git clone https://github.com/awslabs/pgbouncer-fast-switchover.git
@@ -380,7 +383,7 @@ $ docker run -v $(pwd)/pgbouncer.ini:/home/pgbouncer/pgbouncer.ini -v $(pwd)/use
 2023-09-22 20:52:52.649 UTC [9] LOG listening on 0.0.0.0:5432
 2023-09-22 20:52:52.649 UTC [9] LOG listening on [::]:5432
 2023-09-22 20:52:52.649 UTC [9] LOG listening on unix:/tmp/.s.PGSQL.5432
-2023-09-22 20:52:52.650 UTC [9] LOG process up: PgBouncer 1.19.1, libevent 2.1.12-stable (epoll), adns: evdns2, tls: OpenSSL 3.0.8 7 Feb 2023
+2023-09-22 20:52:52.650 UTC [9] LOG process up: PgBouncer 1.24.1, libevent 2.1.12-stable (epoll), adns: evdns2, tls: OpenSSL 3.0.8 7 Feb 2023
 <snip>
 2023-09-29 17:57:01.966 UTC [9] LOG S-0x1508cc0: test-instance-1/master@172.31.14.107:5432 new connection to server (from 172.31.42.81:35612)
 2023-09-29 17:57:01.972 UTC [9] LOG S-0x1508800: test-instance-3/master@172.31.17.50:5432 new connection to server (from 172.31.42.81:36184)
@@ -489,14 +492,14 @@ export BASE_TAG=multiarch-al2
 export BASE_ARM_TAG=arm64
 export BASE_AMD_TAG=amd64
 export PGB_REPO=pgbouncer
-export PGB_TAG=fastswitchover.pg.stable.1.19.multiarch
+export PGB_TAG=fastswitchover.pg.stable.1.24.multiarch
 export PGB_ARM_TAG=arm64
 export PGB_AMD_TAG=amd64
 export GITHUB_OWNER=awslabs
 export GITHUB_BRANCH=ci-build
 export GITHUB_REPO=pgbouncer-fast-switchover
 export PANDOC_VER=3.1.7
-export PGB_GITHUB_BRANCH=stable-1.19
+export PGB_GITHUB_BRANCH=pgbouncer-1.24
 ```
 
 NEED Fix 4 :2/ Build pipeline for the base image

--- a/include/bouncer.h.diff
+++ b/include/bouncer.h.diff
@@ -1,8 +1,8 @@
 diff --git a/include/bouncer.h b/include/bouncer.h
-index f2c2bac..6f45879 100644
+index fccedc5..36b5e11 100644
 --- a/include/bouncer.h
 +++ b/include/bouncer.h
-@@ -99,6 +99,11 @@ typedef struct ScramState ScramState;
+@@ -165,6 +165,11 @@ typedef enum ReplicationType ReplicationType;
  
  extern int cf_sbuf_len;
  
@@ -14,48 +14,49 @@ index f2c2bac..6f45879 100644
  #include "util.h"
  #include "iobuf.h"
  #include "sbuf.h"
-@@ -374,12 +379,31 @@ struct PgPool {
+@@ -455,13 +460,33 @@ struct PgPool {
  
  	/* if last connect to server failed, there should be delay before next */
  	usec_t last_connect_time;
 +	usec_t last_poll_time;
 +	usec_t last_failed_time; // last time the connection failed
- 	bool last_connect_failed:1;
- 	bool last_login_failed:1;
- 
- 	bool welcome_msg_ready:1;
--
-+	bool recently_checked:1; // should be set once checking starts. If all pools have this set, they need to be unset so we can loop again.
-+	bool initial_writer_endpoint:1; // used to indicate a configured writer when starting PgBouncer. Used for getting the topology of the cluster associated with the writer.
-+	bool refresh_topology:1; // after a new writer is found, indicate that we need to refresh the topology.
+	bool last_connect_failed : 1;
+	char last_connect_failed_message[100];
+	bool last_login_failed : 1;
+
+	bool welcome_msg_ready : 1;
+
++	bool recently_checked : 1; // should be set once checking starts. If all pools have this set, they need to be unset so we can loop again.
++	bool initial_writer_endpoint : 1; // used to indicate a configured writer when starting PgBouncer. Used for getting the topology of the cluster associated with the writer.
++	bool refresh_topology : 1; // after a new writer is found, indicate that we need to refresh the topology.
 +	/*
 +	 * Used to indicate that DataRow, CommandComplete, and ReadyForQuery should be discarded.
 +	 * This is for the case where the topology has to be refreshed, but the data should not be
 +	 * sent to the client.
-+	 * 
++	 *
 +	 * Once the ReadyForQuery is received, all topology data has been discarded and regular
 +	 * client server communications can resume.
-+	*/
-+	bool collect_datarows:1; 
-+	bool checking_for_new_writer:1; // this is linked with server and client so we can communicate when polling is truly done. Used to only allow checking for one node a time.
++	 */
++	bool collect_datarows : 1;
++	bool checking_for_new_writer : 1; // this is linked with server and client so we can communicate when polling is truly done. Used to only allow checking for one node a time.
 +
 +	uint16_t num_nodes;
- 	uint16_t rrcounter;		/* round-robin counter */
 +
+	uint16_t rrcounter;		/* round-robin counter */
 +	PgPool *global_writer;	/* global_writer pool for this pool */;
 +	PgPool *parent_pool;	/* the parent pool for setting the global writer */
  };
  
  /*
-@@ -466,6 +490,7 @@ struct PgDatabase {
- 	int pool_mode;		/* pool mode for this database */
+@@ -572,6 +597,7 @@ struct PgDatabase {
  	int max_db_connections;	/* max server connections between all pools */
+	usec_t server_lifetime;	/* max lifetime of server connection */
  	char *connect_query;	/* startup commands to send to server after connect */
 +	char *topology_query;	/* command to get topology to determine promoted writer. Also used to indicate whether to use fast_switchovers on a specific node */
- 
- 	struct PktBuf *startup_params; /* partial StartupMessage (without user) be sent to server */
- 	const char *dbname;	/* server-side name, pointer to inside startup_msg */
-@@ -598,7 +623,9 @@ extern int cf_peer_id;
+	enum LoadBalanceHosts load_balance_hosts;	/* strategy for host selection in a comma-separated host list */
+
+	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
+@@ -783,7 +809,9 @@ extern int cf_peer_id;
  extern int cf_pool_mode;
  extern int cf_max_client_conn;
  extern int cf_default_pool_size;
@@ -65,15 +66,15 @@ index f2c2bac..6f45879 100644
  extern int cf_res_pool_size;
  extern usec_t cf_res_pool_timeout;
  extern int cf_max_db_connections;
-@@ -615,6 +642,7 @@ extern int cf_server_reset_query_always;
- extern char * cf_server_check_query;
+@@ -803,6 +831,7 @@ extern char *cf_server_check_query;
+ extern bool empty_server_check_query;
  extern usec_t cf_server_check_delay;
  extern int cf_server_fast_close;
 +extern usec_t cf_server_failed_delay;
  extern usec_t cf_server_connect_timeout;
  extern usec_t cf_server_login_retry;
  extern usec_t cf_query_timeout;
-@@ -667,6 +695,11 @@ extern int cf_log_disconnections;
+@@ -859,6 +888,11 @@ extern int cf_log_disconnections;
  extern int cf_log_pooler_errors;
  extern int cf_application_name_add_host;
  

--- a/include/loader.h.diff
+++ b/include/loader.h.diff
@@ -1,10 +1,10 @@
 diff --git a/include/loader.h b/include/loader.h
-index dabfc51..8f7ed38 100644
+index 1acbefe..ddb044f 100644
 --- a/include/loader.h
 +++ b/include/loader.h
 @@ -25,3 +25,5 @@ bool parse_user(void *base, const char *name, const char *params) _MUSTCHECK;
  /* user file parsing */
- bool load_auth_file(const char *fn)  /* _MUSTCHECK */;
- bool loader_users_check(void)  /* _MUSTCHECK */;
+ bool load_auth_file(const char *fn) /* _MUSTCHECK */;
+ bool loader_users_check(void) /* _MUSTCHECK */;
 +
 +PgPool *new_pool_from_db(PgDatabase *db, char *dbname, char *hostname);

--- a/include/objects.h.diff
+++ b/include/objects.h.diff
@@ -1,12 +1,14 @@
 diff --git a/include/objects.h b/include/objects.h
-index 7f64ce1..9737490 100644
+index 0b498dd..7fe471d 100644
 --- a/include/objects.h
 +++ b/include/objects.h
-@@ -32,6 +32,7 @@ extern struct Slab *peer_pool_cache;
- extern struct Slab *pool_cache;
- extern struct Slab *user_cache;
- extern struct Slab *iobuf_cache;
+@@ -37,6 +37,9 @@ extern struct Slab *outstanding_request_cache;
+ extern struct Slab *var_list_cache;
+ extern struct Slab *server_prepared_statement_cache;
+ extern PgPreparedStatement *prepared_statements;
 +extern bool fast_switchover;
++/* Store the database info from PgBouncer config to support fast switchover. */
++extern PgDatabase *fast_switchover_db;
+
+ extern unsigned long long int last_pgsocket_id;
  
- PgDatabase *find_peer(int peer_id);
- PgDatabase *find_database(const char *name);

--- a/install-pgbouncer-rr-patch.sh
+++ b/install-pgbouncer-rr-patch.sh
@@ -89,8 +89,9 @@ if [ $patchstatus -eq 1 ]; then
    echo "Possible causes: "
    echo "   pgbouncer-rr-patch already installed in target directory?"
    echo "   new version of pgbouncer with changed source files that can't be patched?"
-   echo "      - last tested with pgbouncer v1.19 (September 2023)"
-   echo "      - Try getting pgbouncer with: git clone https://github.com/pgbouncer/pgbouncer.git --branch \"stable-1.19\""
+   echo "      - last tested with pgbouncer v1.24 (April 2025)"
+   echo "      - Try getting pgbouncer with: git clone https://github.com/pgbouncer/pgbouncer.git"
+   echo "      - cd pgbouncer && git checkout -b pgbouncer-1.24 tags/pgbouncer_1_24_1 && cd .."
    echo "Status: pgbouncer-rr-patch merge FAILED"
 else
    echo "Status: pgbouncer-rr-patch merge SUCEEDED"

--- a/src/admin.c.diff
+++ b/src/admin.c.diff
@@ -1,12 +1,11 @@
 diff --git a/src/admin.c b/src/admin.c
-index 0cf2e8b..c4dbfde 100644
+index b10c333..3bfd2ba 100644
 --- a/src/admin.c
 +++ b/src/admin.c
-@@ -1093,6 +1093,7 @@ static bool admin_cmd_reload(PgSocket *admin, const char *arg)
- 	load_config();
- 	if (!sbuf_tls_setup())
+@@ -1147,6 +1147,7 @@ static bool admin_cmd_reload(PgSocket *admin, const char *arg)
+	load_config();
+	if (!sbuf_tls_setup())
  		log_error("TLS configuration could not be reloaded, keeping old configuration");
 +	run_once_to_init();
- 	return admin_ready(admin, "RELOAD");
+	return admin_ready(admin, "RELOAD");
  }
- 

--- a/src/client.c.diff
+++ b/src/client.c.diff
@@ -1,39 +1,25 @@
 diff --git a/src/client.c b/src/client.c
-index 464d78d..ff64c08 100644
+index fcf7b3b..9cf3b86 100644
 --- a/src/client.c
 +++ b/src/client.c
-@@ -585,10 +585,10 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
- 		} else if (strcmp(key, "application_name") == 0) {
- 			set_appname(client, val);
- 			appname_found = true;
--		} else if (varcache_set(&client->vars, key, val)) {
--			slog_debug(client, "got var: %s=%s", key, val);
- 		} else if (strlist_contains(cf_ignore_startup_params, key)) {
- 			slog_debug(client, "ignoring startup parameter: %s=%s", key, val);
-+		} else if (varcache_set(&client->vars, key, val)) {
-+			slog_debug(client, "got var: %s=%s", key, val);
- 		} else {
- 			slog_warning(client, "unsupported startup parameter: %s=%s", key, val);
- 			disconnect_client(client, true, "unsupported startup parameter: %s", key);
-@@ -798,7 +798,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
+@@ -1291,7 +1291,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
  			return false;
  		}
  
--		if (client->pool && !client->wait_for_user_conn && !client->wait_for_user) {
-+		if (client->pool && !client->wait_for_user_conn && !client->wait_for_user && !get_global_writer(client->pool)) {
+-		if (client->pool && !sending_auth_query(client)) {
++		if (client->pool && !sending_auth_query(client) && !get_global_writer(client->pool)) {
  			disconnect_client(client, true, "client re-sent startup pkt");
  			return false;
  		}
-@@ -923,7 +923,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
- static bool handle_client_work(PgSocket *client, PktHdr *pkt)
- {
- 	SBuf *sbuf = &client->sbuf;
--	int rfq_delta = 0;
-+	int rfq_delta = 0, in_transaction;
+@@ -1428,6 +1428,7 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
+	int track_outstanding = false;
+	PreparedStatementAction ps_action = PS_IGNORE;
+	PgClosePacket close_packet;
++	bool in_transaction = false;
  
  	switch (pkt->type) {
- 
-@@ -980,8 +980,11 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
+	/* one-packet queries */
+@@ -1591,8 +1592,11 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
  		client->query_start = get_cached_time();
  	}
  
@@ -46,12 +32,12 @@ index 464d78d..ff64c08 100644
  		client->pool->stats.xact_count++;
  		client->xact_start = client->query_start;
  	}
-@@ -989,6 +992,14 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
+@@ -1600,6 +1604,14 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
  	if (client->pool->db->admin)
  		return admin_handle_client(client, pkt);
  
 +	/* pgbouncer-rr extensions: query rewrite & client connection routing */
-+	if (pkt->type == 'Q' || pkt->type == 'P') {
++	if (pkt->type == PqMsg_Query || pkt->type == PqMsg_Parse) {
 +		if (!rewrite_query(client, in_transaction, pkt)) {
 +			return false;
 +		}

--- a/src/janitor.c.diff
+++ b/src/janitor.c.diff
@@ -1,5 +1,5 @@
 diff --git a/src/janitor.c b/src/janitor.c
-index 855a4c5..1e02db8 100644
+index 5131ea5..88e6fe8 100644
 --- a/src/janitor.c
 +++ b/src/janitor.c
 @@ -24,6 +24,8 @@
@@ -11,7 +11,7 @@ index 855a4c5..1e02db8 100644
  /* do full maintenance 3x per second */
  static struct timeval full_maint_period = {0, USEC / 3};
  static struct event full_maint_ev;
-@@ -125,21 +127,158 @@ void resume_all(void)
+@@ -127,21 +129,158 @@ void resume_all(void)
  	resume_pooler();
  }
  
@@ -23,8 +23,8 @@ index 855a4c5..1e02db8 100644
 +	if (client->pool == new_pool)
 +		return true;
 +
-+	username = client->login_user->name;
-+	passwd = client->login_user->passwd;
++	username = client->login_user_credentials->name;
++	passwd = client->login_user_credentials->passwd;
 +	if (!set_pool(client, new_pool->db->name, username, passwd, true)) {
 +		log_error("could not set pool to: %s", new_pool->db->name);
 +		return false;
@@ -176,7 +176,7 @@ index 855a4c5..1e02db8 100644
  		if (server->ready)
  			break;
  		disconnect_server(server, true, "idle server got dirty");
-@@ -154,6 +293,31 @@ static void launch_recheck(PgPool *pool)
+@@ -156,6 +295,31 @@ static void launch_recheck(PgPool *pool)
  			need_check = false;
  	}
  
@@ -189,7 +189,7 @@ index 855a4c5..1e02db8 100644
 +				return;
 +			}
 +			slog_debug(server, "P: checking: %s (not done polling)", recovery_query);
-+			SEND_generic(res, server, 'Q', "s", recovery_query);
++			SEND_generic(res, server, PqMsg_Query, "s", recovery_query);
 +			if (!res)
 +				disconnect_server(server, false, "pg_is_in_recovery() query failed");
 +			free(recovery_query);
@@ -208,7 +208,7 @@ index 855a4c5..1e02db8 100644
  	if (need_check) {
  		/* send test query, wait for result */
  		slog_debug(server, "P: checking: %s", q);
-@@ -202,11 +366,22 @@ static void per_loop_activate(PgPool *pool)
+@@ -210,11 +374,22 @@ static void per_loop_activate(PgPool *pool)
  			--sv_tested;
  		} else if (sv_used > 0) {
  			/* ask for more connections to be tested */
@@ -233,7 +233,7 @@ index 855a4c5..1e02db8 100644
  			break;
  		}
  	}
-@@ -298,10 +473,7 @@ static int per_loop_wait_close(PgPool *pool)
+@@ -306,10 +481,7 @@ static int per_loop_wait_close(PgPool *pool)
  	return count;
  }
  
@@ -245,7 +245,7 @@ index 855a4c5..1e02db8 100644
  {
  	struct List *item;
  	PgPool *pool;
-@@ -310,6 +482,7 @@ void per_loop_maint(void)
+@@ -318,6 +490,7 @@ void per_loop_maint(void)
  	bool partial_pause = false;
  	bool partial_wait = false;
  	bool force_suspend = false;
@@ -253,7 +253,7 @@ index 855a4c5..1e02db8 100644
  
  	if (cf_pause_mode == P_SUSPEND && cf_suspend_timeout > 0) {
  		usec_t stime = get_cached_time() - g_suspend_start;
-@@ -321,13 +494,32 @@ void per_loop_maint(void)
+@@ -329,13 +502,32 @@ void per_loop_maint(void)
  		pool = container_of(item, PgPool, head);
  		if (pool->db->admin)
  			continue;
@@ -287,7 +287,7 @@ index 855a4c5..1e02db8 100644
  			}
  			break;
  		case P_PAUSE:
-@@ -366,6 +558,27 @@ void per_loop_maint(void)
+@@ -374,6 +566,37 @@ void per_loop_maint(void)
  		admin_wait_close_done();
  }
  
@@ -299,6 +299,16 @@ index 855a4c5..1e02db8 100644
 +	if (!fast_switchover) {
 +		log_debug("database does not have fast_switchovers enabled, so will not precreate pools to nodes");
 +		return;
++	}
++
++	log_debug("creating pool for %s", fast_switchover_db->name);
++	if (fast_switchover_db && fast_switchover_db->forced_user_credentials) {
++		PgPool *pool = get_pool(fast_switchover_db, fast_switchover_db->forced_user_credentials);
++		if (!pool)
++			fatal("pool could not be created for %s", fast_switchover_db->name);
++	} else {
++		fatal("Failed to create a connection pool for database: %s. Username is missing. To enable fast switchover, "
++			   "please provide a user for this database in config.", fast_switchover_db->name);
 +	}
 +
 +	loop_maint(true);
@@ -315,17 +325,17 @@ index 855a4c5..1e02db8 100644
  /* maintaining clients in pool */
  static void pool_client_maint(PgPool *pool)
  {
-@@ -472,6 +685,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
+@@ -494,6 +717,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
  		} else if (server->state == SV_USED && !server->ready) {
  			disconnect_server(server, true, "SV_USED server got dirty");
  		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
 +			   && (pool->db && !pool->db->topology_query)
  			   && (pool_min_pool_size(pool) == 0 || pool_connected_server_count(pool) > pool_min_pool_size(pool))) {
  			disconnect_server(server, true, "server idle timeout");
- 		} else if (age >= cf_server_lifetime) {
-@@ -801,6 +1015,7 @@ void kill_database(PgDatabase *db)
- 	if (db->forced_user)
- 		slab_free(user_cache, db->forced_user);
+		} else if (age >= server_lifetime) {
+@@ -877,6 +1101,7 @@ void kill_database(PgDatabase *db)
+	if (db->forced_user_credentials)
+		slab_free(credentials_cache, db->forced_user_credentials);
  	free(db->connect_query);
 +	free(db->topology_query);
  	if (db->inactive_time) {

--- a/src/loader.c.diff
+++ b/src/loader.c.diff
@@ -1,8 +1,16 @@
 diff --git a/src/loader.c b/src/loader.c
-index 55f87a8..4db4b57 100644
+index fd2e7ab..9692913 100644
 --- a/src/loader.c
 +++ b/src/loader.c
-@@ -61,12 +61,20 @@ static char *cstr_unquote_value(char *p)
+@@ -32,6 +32,7 @@
+
+ bool any_user_level_timeout_set;
+ bool any_user_level_client_timeout_set;
++PgDatabase *fast_switchover_db;
+
+ /* parse parameter name before '=' */
+ static char *cstr_get_key(char *p, char **dst_p)
+@@ -57,12 +58,20 @@ static char *cstr_unquote_value(char *p)
  	while (1) {
  		if (!*p)
  			return NULL;
@@ -23,8 +31,8 @@ index 55f87a8..4db4b57 100644
  		*s++ = *p++;
  	}
  	/* terminate actual value */
-@@ -260,6 +268,76 @@ fail:
- 	free(tmp_connstr);
+@@ -243,6 +252,76 @@ fail:
+	free(host);
  	return false;
  }
 +
@@ -79,14 +87,14 @@ index 55f87a8..4db4b57 100644
 +			goto oom;
 +	}
 +
-+	if (db->forced_user) {
-+		if (!force_user(new_db, db->forced_user->name, db->forced_user->passwd)) {;
++	if (db->forced_user_credentials) {
++		if (!force_user_credentials(new_db, db->forced_user_credentials->name, db->forced_user_credentials->passwd)) {;
 +			goto oom;
 +		}
 +	}
 +
 +	log_debug("creating pool for %s", new_db->name);
-+	pool = get_pool(new_db, new_db->forced_user);
++	pool = get_pool(new_db, new_db->forced_user_credentials);
 +	if (!pool) {
 +		fatal("pool could not be created for %s", new_db->name);
 +		goto oom;
@@ -100,15 +108,15 @@ index 55f87a8..4db4b57 100644
  /* fill PgDatabase from connstr */
  bool parse_database(void *base, const char *name, const char *connstr)
  {
-@@ -286,6 +364,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -273,6 +352,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	char *datestyle = NULL;
  	char *timezone = NULL;
  	char *connect_query = NULL;
 +	char *topology_query = NULL;
  	char *appname = NULL;
+	char *auth_query = NULL;
  
- 	cv.value_p = &pool_mode;
-@@ -358,11 +437,26 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -358,8 +438,20 @@ bool parse_database(void *base, const char *name, const char *connstr)
  				goto fail;
  			}
  		} else if (strcmp("connect_query", key) == 0) {
@@ -116,54 +124,46 @@ index 55f87a8..4db4b57 100644
 +				log_error("connect_query cannot be used if topology_query is set");
 +				goto fail;
 +			}
- 			connect_query = strdup(val);
- 			if (!connect_query) {
- 				log_error("out of memory");
+			if (!set_param_value(&connect_query, val))
  				goto fail;
- 			}
 +		} else if (strcmp("topology_query", key) == 0) {
 +			if (connect_query != NULL) {
 +				log_error("topology_query cannot be used if connect_query is set");
 +				goto fail;
 +			}
-+			topology_query = strdup(val);
-+			if (!topology_query) {
-+				log_error("out of memory");
++			if (!set_param_value(&topology_query, val))
 +				goto fail;
-+			}
 +			fast_switchover = true;
  		} else if (strcmp("application_name", key) == 0) {
  			appname = val;
- 		} else {
-@@ -400,6 +494,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
+		} else if (strcmp("auth_query", key) == 0) {
+@@ -399,6 +491,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
  			changed = true;
- 		} else if (!strings_equal(connect_query, db->connect_query)) {
+		} else if (!strcmpeq(connect_query, db->connect_query)) {
  			changed = true;
-+		} else if (!strings_equal(topology_query, db->topology_query)) {
++		} else if (!strcmpeq(topology_query, db->topology_query)) {
 +			changed = true;
- 		} else if (!strings_equal(db->auth_dbname, auth_dbname)) {
+		} else if (!strcmpeq(db->auth_dbname, auth_dbname)) {
  			changed = true;
- 		}
-@@ -416,7 +512,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
- 	db->pool_mode = pool_mode;
- 	db->max_db_connections = max_db_connections;
+		} else if (!strcmpeq(db->auth_query, auth_query)) {
+@@ -423,8 +517,11 @@ bool parse_database(void *base, const char *name, const char *connstr)
+	db->server_lifetime = server_lifetime;
+	db->load_balance_hosts = load_balance_hosts;
  	free(db->connect_query);
 +	free(db->topology_query);
  	db->connect_query = connect_query;
 +	db->topology_query = topology_query;
- 
- 	if (!set_auth_dbname(db, auth_dbname))
+	connect_query = NULL;
++	topology_query = NULL;
+
+	if (!set_param_value(&db->auth_dbname, auth_dbname))
  		goto fail;
-@@ -476,6 +574,13 @@ bool parse_database(void *base, const char *name, const char *connstr)
+@@ -486,6 +583,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
  	/* remember dbname */
  	db->dbname = (char *)msg->buf + dbname_ofs;
  
-+	log_debug("creating pool for %s", db->name);
-+	if (db->forced_user) {
-+		PgPool *pool = get_pool(db, db->forced_user);
-+		if (!pool)
-+			fatal("pool could not be created for %s", db->name);
-+	}
++	if (fast_switchover)
++		fast_switchover_db = db;
 +
  	free(tmp_connstr);
  	return true;

--- a/src/main.c.diff
+++ b/src/main.c.diff
@@ -1,8 +1,8 @@
 diff --git a/src/main.c b/src/main.c
-index 3fc1a0c..dba92f2 100644
+index 88b94c8..6988314 100644
 --- a/src/main.c
 +++ b/src/main.c
-@@ -119,7 +119,9 @@ char *cf_auth_dbname;
+@@ -122,7 +122,9 @@ char *cf_track_extra_parameters;
  
  int cf_max_client_conn;
  int cf_default_pool_size;
@@ -12,7 +12,7 @@ index 3fc1a0c..dba92f2 100644
  int cf_res_pool_size;
  usec_t cf_res_pool_timeout;
  int cf_max_db_connections;
-@@ -130,6 +132,7 @@ int cf_server_reset_query_always;
+@@ -135,6 +137,7 @@ int cf_server_reset_query_always;
  char *cf_server_check_query;
  usec_t cf_server_check_delay;
  int cf_server_fast_close;
@@ -20,7 +20,7 @@ index 3fc1a0c..dba92f2 100644
  int cf_server_round_robin;
  int cf_disable_pqexec;
  usec_t cf_dns_max_ttl;
-@@ -171,6 +174,11 @@ int cf_log_disconnections;
+@@ -176,6 +179,11 @@ int cf_log_disconnections;
  int cf_log_pooler_errors;
  int cf_application_name_add_host;
  
@@ -32,35 +32,35 @@ index 3fc1a0c..dba92f2 100644
  int cf_client_tls_sslmode;
  char *cf_client_tls_protocols;
  char *cf_client_tls_ca_file;
-@@ -273,18 +281,27 @@ CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),
- CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),
- CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
- CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
-+// in seconds. maps to 100ms by default.
-+CF_ABS("polling_frequency", CF_TIME_USEC, cf_polling_frequency, 0, ".1"),
- CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
- CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
- CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
- CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
-+CF_ABS("recreate_disconnected_pools", DEFER_OPS, cf_recreate_disconnected_pools, 0, "1"),
- CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
- CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
- CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
-+/* pgbouncer-rr extensions */
-+CF_ABS("routing_rules_py_module_file", CF_STR, cf_routing_rules_py_module_file, 0, "not_enabled"),
-+CF_ABS("rewrite_query_py_module_file", CF_STR, cf_rewrite_query_py_module_file, 0, "not_enabled"),
-+CF_ABS("rewrite_query_disconnect_on_failure", CF_STR, cf_rewrite_query_disconnect_on_failure, 0, "false"),
- CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
- CF_ABS("server_check_delay", CF_TIME_USEC, cf_server_check_delay, 0, "30"),
- CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
- CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
- CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
-+// allow backing off after switchover/failover. The delay to wait until reopening failed connections.
-+CF_ABS("server_failed_delay", CF_TIME_USEC, cf_server_failed_delay, 0, "30"),
- CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
- CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
- CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
-@@ -1040,6 +1057,8 @@ int main(int argc, char *argv[])
+@@ -290,18 +298,27 @@ static const struct CfKey bouncer_params [] = {
+	CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),
+	CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
+	CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
++	// in seconds. maps to 100ms by default.
++	CF_ABS("polling_frequency", CF_TIME_USEC, cf_polling_frequency, 0, ".1"),
+	CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
+	CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
+	CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
+	CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
++	CF_ABS("recreate_disconnected_pools", DEFER_OPS, cf_recreate_disconnected_pools, 0, "1"),
+	CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
+	CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
+	CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
++	/* pgbouncer-rr extensions */
++	CF_ABS("routing_rules_py_module_file", CF_STR, cf_routing_rules_py_module_file, 0, "not_enabled"),
++	CF_ABS("rewrite_query_py_module_file", CF_STR, cf_rewrite_query_py_module_file, 0, "not_enabled"),
++	CF_ABS("rewrite_query_disconnect_on_failure", CF_STR, cf_rewrite_query_disconnect_on_failure, 0, "false"),
+	CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
+	CF_ABS("server_check_delay", CF_TIME_USEC, cf_server_check_delay, 0, "30"),
+	CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
+	CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
+	CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
++	// allow backing off after switchover/failover. The delay to wait until reopening failed connections.
++	CF_ABS("server_failed_delay", CF_TIME_USEC, cf_server_failed_delay, 0, "30"),
+	CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
+	CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
+	CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
+@@ -1129,6 +1146,8 @@ int main(int argc, char *argv[])
  	}
  
  	write_pidfile();

--- a/src/objects.c.diff
+++ b/src/objects.c.diff
@@ -1,17 +1,17 @@
 diff --git a/src/objects.c b/src/objects.c
-index ab662b8..e073699 100644
+index 5603c74..54f18ec 100644
 --- a/src/objects.c
 +++ b/src/objects.c
-@@ -643,14 +643,20 @@ PgPool *get_pool(PgDatabase *db, PgUser *user)
+@@ -769,14 +769,20 @@ PgPool *get_pool(PgDatabase *db, PgCredentials *user_credentials)
  {
  	struct List *item;
  	PgPool *pool;
 +	PgPool *global_writer = NULL;
- 
- 	if (!db || !user)
+
+	if (!db || !user_credentials)
  		return NULL;
- 
- 	list_for_each(item, &user->pool_list) {
+
+	list_for_each(item, &user_credentials->global_user->pool_list) {
  		pool = container_of(item, PgPool, map_head);
 -		if (pool->db == db)
 +		if (pool->db == db) {
@@ -22,20 +22,20 @@ index ab662b8..e073699 100644
  			return pool;
 +		}
  	}
- 
- 	return new_pool(db, user);
-@@ -854,6 +860,10 @@ bool life_over(PgSocket *server)
- 	usec_t age = now - server->connect_time;
+
+	return new_pool(db, user_credentials);
+@@ -1175,6 +1181,10 @@ bool life_over(PgSocket *server)
  	usec_t last_kill = now - pool->last_lifetime_disconnect;
+	usec_t server_lifetime = pool_server_lifetime(pool);
  
 +	// never close the pools when using fast switchovers
 +	if (pool->db && pool->db->topology_query)
 +		return false;
 +
- 	if (age < cf_server_lifetime)
+	if (age < server_lifetime)
  		return false;
  
-@@ -1589,6 +1599,8 @@ PgSocket *accept_client(int sock, bool is_unix)
+@@ -2022,6 +2032,8 @@ PgSocket *accept_client(int sock, bool is_unix)
  /* client managed to authenticate, send welcome msg and accept queries */
  bool finish_client_login(PgSocket *client)
  {
@@ -43,8 +43,8 @@ index ab662b8..e073699 100644
 +
  	if (client->db->fake) {
  		if (cf_log_connections)
- 			slog_info(client, "login failed: db=%s user=%s", client->db->name, client->login_user->name);
-@@ -1603,6 +1615,21 @@ bool finish_client_login(PgSocket *client)
+			slog_info(client, "login failed: db=%s user=%s", client->db->name, client->login_user_credentials->name);
+@@ -2041,6 +2053,21 @@ bool finish_client_login(PgSocket *client)
  
  	switch (client->state) {
  	case CL_LOGIN:
@@ -56,7 +56,7 @@ index ab662b8..e073699 100644
 +			log_debug("finish_client_login: no topology query, so not using fast switchover");
 +		} else if (global_writer) {
 +			log_debug("finish_client_login: global writer is set, so let's use the cached value: %s", global_writer->db->name);
-+			if (client->pool != global_writer && !set_pool(client, global_writer->db->name, client->login_user->name, client->login_user->passwd, true)) {
++			if (client->pool != global_writer && !set_pool(client, global_writer->db->name, client->login_user_credentials->name, client->login_user_credentials->passwd, true)) {
 +				log_error("could not set pool to: %s", global_writer->db->name);
 +				return false;
 +			}

--- a/src/server.c.diff
+++ b/src/server.c.diff
@@ -1,10 +1,10 @@
 diff --git a/src/server.c b/src/server.c
-index 46db05a..f53d3b6 100644
+index 4a4bbb7..7632738 100644
 --- a/src/server.c
 +++ b/src/server.c
-@@ -22,6 +22,44 @@
+@@ -27,6 +27,44 @@
  
- #include "bouncer.h"
+ #define ERRCODE_CANNOT_CONNECT_NOW "57P03"
  
 +/*
 +* Returns the query data from the server. This must be freed.
@@ -47,8 +47,8 @@ index 46db05a..f53d3b6 100644
  static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
  {
  	const char *key, *val;
-@@ -92,6 +130,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
- 	SBuf *sbuf = &server->sbuf;
+@@ -122,6 +160,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+	const char *msg;
  	bool res = false;
  	const uint8_t *ckey;
 +	char *data = NULL;
@@ -56,27 +56,28 @@ index 46db05a..f53d3b6 100644
  
  	if (incomplete_pkt(pkt)) {
  		disconnect_server(server, true, "partial pkt in login phase");
-@@ -102,11 +142,15 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
- 	if (server->exec_on_connect) {
+@@ -133,12 +173,16 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		switch (pkt->type) {
- 		case 'Z':
-+		case 'D':
- 		case 'S':	/* handle them below */
+		case PqMsg_ReadyForQuery:
+		case PqMsg_ParameterStatus:
++		case PqMsg_DataRow:
+			/* handle them below */
  			break;
- 
- 		case 'E':	/* log & ignore errors */
+
+		case PqMsg_ErrorResponse:
+			/* log & ignore errors */
  			log_server_error("S: error while executing exec_on_query", pkt);
 +			// require topology table to exist in the cluster if using
 +			if (fast_switchover)
 +				fatal("does the topology table exist?");
- 			/* fallthrough */
+		/* fallthrough */
  		default:	/* ignore rest */
  			sbuf_prepare_skip(sbuf, pkt->len);
-@@ -120,6 +164,38 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
+@@ -152,6 +196,38 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  		disconnect_server(server, true, "unknown pkt from server");
  		break;
  
-+	case 'D':       /* DataRow */
++	case PqMsg_DataRow:
 +		if (fast_switchover && server->pool->db->topology_query && server->pool->initial_writer_endpoint) {
 +			data = query_data(pkt);
 +			log_debug("got initial data: %s", data);
@@ -107,18 +108,18 @@ index 46db05a..f53d3b6 100644
 +
 +		sbuf_prepare_skip(sbuf, pkt->len);
 +		return true;
-+		break;
- 	case 'E':		/* ErrorResponse */
- 		if (!server->pool->welcome_msg_ready)
- 			kill_pool_logins_server_error(server->pool, pkt);
-@@ -152,8 +228,20 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
++
+	case PqMsg_ErrorResponse:
+		/*
+		 * If we cannot log into the server, then we drop all clients
+@@ -201,8 +277,20 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
  			if (!res)
  				disconnect_server(server, false, "exec_on_connect query failed");
  			break;
 +		} else if (fast_switchover && server->pool->db->topology_query && server->pool->initial_writer_endpoint) {
 +			server->exec_on_connect = true;
 +			slog_debug(server, "server connect ok, send topology_query: %s", server->pool->db->topology_query);
-+			SEND_generic(res, server, 'Q', "s", server->pool->db->topology_query);
++			SEND_generic(res, server, PqMsg_Query, "s", server->pool->db->topology_query);
 +			if (!res)
 +				disconnect_server(server, false, "exec_on_connect query failed");
 +			break;
@@ -132,18 +133,18 @@ index 46db05a..f53d3b6 100644
  		/* login ok */
  		slog_debug(server, "server login ok, start accepting queries");
  		server->ready = true;
-@@ -250,6 +338,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
- 	SBuf *sbuf = &server->sbuf;
- 	PgSocket *client = server->link;
+@@ -363,6 +451,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	bool async_response = false;
+	struct List *item, *tmp;
+	bool ignore_packet = false;
 +	bool res = false;
  
  	Assert(!server->pool->db->admin);
  
-@@ -261,6 +350,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+@@ -374,6 +463,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  
  	/* pooling decisions will be based on this packet */
- 	case 'Z':		/* ReadyForQuery */
+	case PqMsg_ReadyForQuery:
 +		/*
 +		 * Discard topology data without sending to the client is finished. Resume regular
 +		 * client/server communication.
@@ -156,10 +157,10 @@ index 46db05a..f53d3b6 100644
  
  		/* if partial pkt, wait */
  		if (!mbuf_get_char(&pkt->data, &state))
-@@ -318,6 +416,13 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
- 		}
- 		/* fallthrough */
- 	case 'C':		/* CommandComplete */
+@@ -461,6 +559,14 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+		break;
+
+	case PqMsg_CommandComplete:
 +		/*
 +		 * In the process of discarding topology data without sending to the client.
 +		 */
@@ -167,13 +168,14 @@ index 46db05a..f53d3b6 100644
 +			sbuf_prepare_skip(sbuf, pkt->len);
 +			return true;
 +		}
- 
++
  		/* ErrorResponse and CommandComplete show end of copy mode */
  		if (server->copy_mode) {
-@@ -358,6 +463,29 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+			slog_debug(server, "COPY finished");
+@@ -545,6 +651,29 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  	/* data packets, there will be more coming */
- 	case 'd':		/* CopyData(F/B) */
- 	case 'D':		/* DataRow */
+	case PqMsg_CopyData:
+	case PqMsg_DataRow:
 +		/*
 +		 * These are the rows returned from the topology query that are discarded.
 +		 */
@@ -197,18 +199,19 @@ index 46db05a..f53d3b6 100644
 +			server->pool->checking_for_new_writer = false;
 +			free(data);
 +		}
- 	case 't':		/* ParameterDescription */
- 	case 'T':		/* RowDescription */
  		break;
-@@ -418,13 +546,26 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
+	}
+	server->idle_tx = idle_tx;
+@@ -632,7 +761,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  			}
  		}
  	} else {
--		if (server->state != SV_TESTED)
-+		if (server->state != SV_TESTED && !server->pool->db->topology_query)
+-		if (server->state != SV_TESTED) {
++		if (server->state != SV_TESTED && !server->pool->db->topology_query) {
  			slog_warning(server,
  				     "got packet '%c' from server when not linked",
  				     pkt_desc(pkt));
+@@ -640,6 +769,19 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
  		sbuf_prepare_skip(sbuf, pkt->len);
  	}
  
@@ -220,15 +223,15 @@ index 46db05a..f53d3b6 100644
 +		server->pool->collect_datarows = true;
 +		server->pool->refresh_topology = false;
 +
-+		SEND_generic(res, server, 'Q', "s", server->pool->db->topology_query);
++		SEND_generic(res, server, PqMsg_Query, "s", server->pool->db->topology_query);
 +		if (!res)
 +			disconnect_server(server, false, "exec_on_connect query failed");
-+	}
++		}
 +
  	return true;
  }
  
-@@ -538,6 +679,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -754,6 +896,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	bool res = false;
  	PgSocket *server = container_of(sbuf, PgSocket, sbuf);
  	PgPool *pool = server->pool;
@@ -236,7 +239,7 @@ index 46db05a..f53d3b6 100644
  	PktHdr pkt;
  	char infobuf[96];
  
-@@ -552,8 +694,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -768,8 +911,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  	case SBUF_EV_RECV_FAILED:
  		if (server->state == SV_ACTIVE_CANCEL)
  			disconnect_server(server, false, "successfully sent cancel request");
@@ -256,7 +259,7 @@ index 46db05a..f53d3b6 100644
  		break;
  	case SBUF_EV_SEND_FAILED:
  		disconnect_client(server->link, false, "unexpected eof");
-@@ -593,6 +745,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
+@@ -810,6 +963,10 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
  		break;
  	case SBUF_EV_CONNECT_FAILED:
  		Assert(server->state == SV_LOGIN);


### PR DESCRIPTION
This PR reapplies the pgbouncer-fast-switchover patch on top of the stable PgBouncer release v1.24.1.

Motivation :
The primary goals of this upgrade are:
*  To leverage enhancements introduced in PgBouncer v1.21 and later, including key features such as prepared statements and improved connection handling.

*Description of changes:*

Bug Fix :
*  Since v1.21, PgBouncer includes a varcache system that is initialised in init_caches.
*  However, parse_database is invoked before init_caches, which leads to a null pointer dereference in new_pool when it attempts to access var_list_cache.
* Previously, pools for configured databases were being created while loading the config file.
* This logic has now been moved to run_once_to_init(), which is invoked during PgBouncer startup and on RELOAD.
* This ensures that varcache initialization is complete before any pool creation occurs.

This PR resolves the issue by addressing the initialisation sequence safely and maintaining compatibility with the current configuration logic.

Testing :
* Verified the fast switchover feature using a Multi-AZ cluster with the PgBouncer version (v1.24.1).
* Confirmed that the standard PgBouncer behavior works as expected with a PostgreSQL database.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
